### PR TITLE
Swagger UI 연동 및 Controller 인터페이스 분리

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers:2.0.3")
     testImplementation("org.testcontainers:testcontainers-mysql:2.0.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2")
 }
 
 tasks.named<Test>("test") {

--- a/src/main/java/com/intime/config/SwaggerConfig.java
+++ b/src/main/java/com/intime/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.intime.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("InTime API")
+                        .version("v1")
+                        .description("웨이팅 순번 교환 플랫폼 - Time is Gold"));
+    }
+}

--- a/src/main/java/com/intime/presentation/member/MemberController.java
+++ b/src/main/java/com/intime/presentation/member/MemberController.java
@@ -5,6 +5,7 @@ import com.intime.domain.member.Member;
 import com.intime.presentation.member.dto.MemberResponse;
 import com.intime.presentation.member.dto.NicknameUpdateRequest;
 import com.intime.presentation.member.dto.SignupRequest;
+import com.intime.presentation.member.api.MemberApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/members")
-public class MemberController {
+public class MemberController implements MemberApi {
 
     private final MemberService memberService;
 

--- a/src/main/java/com/intime/presentation/member/api/MemberApi.java
+++ b/src/main/java/com/intime/presentation/member/api/MemberApi.java
@@ -1,0 +1,33 @@
+package com.intime.presentation.member.api;
+
+import com.intime.presentation.member.dto.MemberResponse;
+import com.intime.presentation.member.dto.NicknameUpdateRequest;
+import com.intime.presentation.member.dto.SignupRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Member", description = "회원 관련 API")
+@RequestMapping("/api/v1/members")
+public interface MemberApi {
+
+    @Operation(summary = "회원가입")
+    @ApiResponse(responseCode = "201", description = "회원가입 성공")
+    @PostMapping("/signup")
+    ResponseEntity<MemberResponse> signup(@RequestBody SignupRequest request);
+
+    @Operation(summary = "회원 조회")
+    @ApiResponse(responseCode = "200", description = "회원 조회 성공")
+    @GetMapping("/{memberId}")
+    ResponseEntity<MemberResponse> getMember(@PathVariable Long memberId);
+
+    @Operation(summary = "닉네임 수정")
+    @ApiResponse(responseCode = "200", description = "닉네임 수정 성공")
+    @PatchMapping("/{memberId}")
+    ResponseEntity<MemberResponse> updateNickname(
+            @PathVariable Long memberId,
+            @RequestBody NicknameUpdateRequest request
+    );
+}

--- a/src/main/java/com/intime/presentation/negotiation/NegotiationController.java
+++ b/src/main/java/com/intime/presentation/negotiation/NegotiationController.java
@@ -5,13 +5,14 @@ import com.intime.domain.negotiation.Negotiation;
 import com.intime.presentation.negotiation.dto.NegotiationFinalOfferRequest;
 import com.intime.presentation.negotiation.dto.NegotiationOfferRequest;
 import com.intime.presentation.negotiation.dto.NegotiationResponse;
+import com.intime.presentation.negotiation.api.NegotiationApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-public class NegotiationController {
+public class NegotiationController implements NegotiationApi {
 
     private final NegotiationService negotiationService;
 

--- a/src/main/java/com/intime/presentation/negotiation/api/NegotiationApi.java
+++ b/src/main/java/com/intime/presentation/negotiation/api/NegotiationApi.java
@@ -1,0 +1,54 @@
+package com.intime.presentation.negotiation.api;
+
+import com.intime.presentation.negotiation.dto.NegotiationFinalOfferRequest;
+import com.intime.presentation.negotiation.dto.NegotiationOfferRequest;
+import com.intime.presentation.negotiation.dto.NegotiationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Negotiation", description = "가격 협상 관련 API")
+public interface NegotiationApi {
+
+    @Operation(summary = "오퍼 제시")
+    @ApiResponse(responseCode = "200", description = "오퍼 제시 성공")
+    @PostMapping("/api/v1/negotiations/{negotiationId}/offers")
+    ResponseEntity<NegotiationResponse> makeOffer(
+            @PathVariable Long negotiationId,
+            @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId,
+            @RequestBody NegotiationOfferRequest request
+    );
+
+    @Operation(summary = "오퍼 수락")
+    @ApiResponse(responseCode = "204", description = "오퍼 수락 성공")
+    @PostMapping("/api/v1/negotiations/{negotiationId}/accept")
+    ResponseEntity<Void> accept(
+            @PathVariable Long negotiationId,
+            @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId
+    );
+
+    @Operation(summary = "오퍼 거절")
+    @ApiResponse(responseCode = "204", description = "오퍼 거절 성공")
+    @PostMapping("/api/v1/negotiations/{negotiationId}/reject")
+    ResponseEntity<Void> reject(
+            @PathVariable Long negotiationId,
+            @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId
+    );
+
+    @Operation(summary = "최종 입찰 제출 (FINAL_ROUND)")
+    @ApiResponse(responseCode = "204", description = "최종 입찰 제출 성공")
+    @PostMapping("/api/v1/negotiations/{negotiationId}/final-offer")
+    ResponseEntity<Void> submitFinalOffer(
+            @PathVariable Long negotiationId,
+            @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId,
+            @RequestBody NegotiationFinalOfferRequest request
+    );
+
+    @Operation(summary = "협상 조회")
+    @ApiResponse(responseCode = "200", description = "협상 조회 성공")
+    @GetMapping("/api/v1/negotiations/{negotiationId}")
+    ResponseEntity<NegotiationResponse> getNegotiation(@PathVariable Long negotiationId);
+}

--- a/src/main/java/com/intime/presentation/store/StoreController.java
+++ b/src/main/java/com/intime/presentation/store/StoreController.java
@@ -4,6 +4,7 @@ import com.intime.application.store.StoreService;
 import com.intime.domain.store.Store;
 import com.intime.presentation.store.dto.StoreCreateRequest;
 import com.intime.presentation.store.dto.StoreResponse;
+import com.intime.presentation.store.api.StoreApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +15,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/stores")
-public class StoreController {
+public class StoreController implements StoreApi {
 
     private final StoreService storeService;
 

--- a/src/main/java/com/intime/presentation/store/api/StoreApi.java
+++ b/src/main/java/com/intime/presentation/store/api/StoreApi.java
@@ -1,0 +1,31 @@
+package com.intime.presentation.store.api;
+
+import com.intime.presentation.store.dto.StoreCreateRequest;
+import com.intime.presentation.store.dto.StoreResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Store", description = "가게 관련 API")
+@RequestMapping("/api/v1/stores")
+public interface StoreApi {
+
+    @Operation(summary = "가게 등록")
+    @ApiResponse(responseCode = "201", description = "가게 등록 성공")
+    @PostMapping
+    ResponseEntity<StoreResponse> createStore(@RequestBody StoreCreateRequest request);
+
+    @Operation(summary = "가게 목록 조회")
+    @ApiResponse(responseCode = "200", description = "가게 목록 조회 성공")
+    @GetMapping
+    ResponseEntity<List<StoreResponse>> getStores();
+
+    @Operation(summary = "가게 단건 조회")
+    @ApiResponse(responseCode = "200", description = "가게 단건 조회 성공")
+    @GetMapping("/{storeId}")
+    ResponseEntity<StoreResponse> getStore(@PathVariable Long storeId);
+}

--- a/src/main/java/com/intime/presentation/trade/ExchangeRequestController.java
+++ b/src/main/java/com/intime/presentation/trade/ExchangeRequestController.java
@@ -4,6 +4,7 @@ import com.intime.application.trade.ExchangeRequestService;
 import com.intime.domain.trade.ExchangeRequest;
 import com.intime.presentation.trade.dto.ExchangeRequestCreateRequest;
 import com.intime.presentation.trade.dto.ExchangeRequestResponse;
+import com.intime.presentation.trade.api.ExchangeRequestApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +14,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-public class ExchangeRequestController {
+public class ExchangeRequestController implements ExchangeRequestApi {
 
     private final ExchangeRequestService exchangeRequestService;
 

--- a/src/main/java/com/intime/presentation/trade/TradePostController.java
+++ b/src/main/java/com/intime/presentation/trade/TradePostController.java
@@ -4,6 +4,7 @@ import com.intime.application.trade.TradePostService;
 import com.intime.domain.trade.TradePost;
 import com.intime.presentation.trade.dto.TradePostCreateRequest;
 import com.intime.presentation.trade.dto.TradePostResponse;
+import com.intime.presentation.trade.api.TradePostApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +14,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-public class TradePostController {
+public class TradePostController implements TradePostApi {
 
     private final TradePostService tradePostService;
 

--- a/src/main/java/com/intime/presentation/trade/api/ExchangeRequestApi.java
+++ b/src/main/java/com/intime/presentation/trade/api/ExchangeRequestApi.java
@@ -1,0 +1,46 @@
+package com.intime.presentation.trade.api;
+
+import com.intime.presentation.trade.dto.ExchangeRequestCreateRequest;
+import com.intime.presentation.trade.dto.ExchangeRequestResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Exchange Request", description = "순번 교환 신청 관련 API")
+public interface ExchangeRequestApi {
+
+    @Operation(summary = "순번 교환 신청")
+    @ApiResponse(responseCode = "201", description = "교환 신청 성공")
+    @PostMapping("/api/v1/trade-posts/{postId}/requests")
+    ResponseEntity<ExchangeRequestResponse> requestExchange(
+            @PathVariable Long postId,
+            @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId,
+            @RequestBody ExchangeRequestCreateRequest request
+    );
+
+    @Operation(summary = "교환 신청 취소")
+    @ApiResponse(responseCode = "204", description = "교환 신청 취소 성공")
+    @DeleteMapping("/api/v1/exchange-requests/{requestId}")
+    ResponseEntity<Void> cancelRequest(
+            @PathVariable Long requestId,
+            @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId
+    );
+
+    @Operation(summary = "게시글 교환 신청 목록 조회")
+    @ApiResponse(responseCode = "200", description = "신청 목록 조회 성공")
+    @GetMapping("/api/v1/trade-posts/{postId}/requests")
+    ResponseEntity<List<ExchangeRequestResponse>> getRequests(@PathVariable Long postId);
+
+    @Operation(summary = "구매자 선택 (협상 자동 시작)")
+    @ApiResponse(responseCode = "204", description = "구매자 선택 성공")
+    @PostMapping("/api/v1/exchange-requests/{requestId}/select")
+    ResponseEntity<Void> selectBuyer(
+            @PathVariable Long requestId,
+            @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId
+    );
+}

--- a/src/main/java/com/intime/presentation/trade/api/TradePostApi.java
+++ b/src/main/java/com/intime/presentation/trade/api/TradePostApi.java
@@ -1,0 +1,38 @@
+package com.intime.presentation.trade.api;
+
+import com.intime.presentation.trade.dto.TradePostCreateRequest;
+import com.intime.presentation.trade.dto.TradePostResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Trade Post", description = "순번 교환 게시글 관련 API")
+public interface TradePostApi {
+
+    @Operation(summary = "순번 교환 게시글 등록")
+    @ApiResponse(responseCode = "201", description = "게시글 등록 성공")
+    @PostMapping("/api/v1/waiting/{ticketId}/trade-post")
+    ResponseEntity<TradePostResponse> register(
+            @PathVariable Long ticketId,
+            @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId,
+            @RequestBody TradePostCreateRequest request
+    );
+
+    @Operation(summary = "순번 교환 게시글 취소")
+    @ApiResponse(responseCode = "204", description = "게시글 취소 성공")
+    @DeleteMapping("/api/v1/trade-posts/{postId}")
+    ResponseEntity<Void> withdraw(
+            @PathVariable Long postId,
+            @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId
+    );
+
+    @Operation(summary = "가게 교환 게시글 목록 조회")
+    @ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공")
+    @GetMapping("/api/v1/stores/{storeId}/trade-posts")
+    ResponseEntity<List<TradePostResponse>> getStoreTradePosts(@PathVariable Long storeId);
+}

--- a/src/main/java/com/intime/presentation/waiting/WaitingController.java
+++ b/src/main/java/com/intime/presentation/waiting/WaitingController.java
@@ -4,6 +4,7 @@ import com.intime.application.waiting.WaitingService;
 import com.intime.domain.waiting.WaitingTicket;
 import com.intime.presentation.waiting.dto.WaitingRegisterRequest;
 import com.intime.presentation.waiting.dto.WaitingTicketResponse;
+import com.intime.presentation.waiting.api.WaitingApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-public class WaitingController {
+public class WaitingController implements WaitingApi {
 
     private final WaitingService waitingService;
 

--- a/src/main/java/com/intime/presentation/waiting/WaitingQueryController.java
+++ b/src/main/java/com/intime/presentation/waiting/WaitingQueryController.java
@@ -7,6 +7,7 @@ import com.intime.domain.trade.TradePost;
 import com.intime.domain.waiting.WaitingTicket;
 import com.intime.presentation.waiting.dto.WaitingTicketResponse;
 import com.intime.presentation.waiting.dto.WaitingTicketResponse.TradePostInfo;
+import com.intime.presentation.waiting.api.WaitingQueryApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,7 +18,7 @@ import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
-public class WaitingQueryController {
+public class WaitingQueryController implements WaitingQueryApi {
 
     private final WaitingQueryService waitingQueryService;
     private final TradePostService tradePostService;

--- a/src/main/java/com/intime/presentation/waiting/api/WaitingApi.java
+++ b/src/main/java/com/intime/presentation/waiting/api/WaitingApi.java
@@ -1,0 +1,46 @@
+package com.intime.presentation.waiting.api;
+
+import com.intime.presentation.waiting.dto.WaitingRegisterRequest;
+import com.intime.presentation.waiting.dto.WaitingTicketResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Waiting", description = "웨이팅 대기표 관련 API")
+public interface WaitingApi {
+
+    @Operation(summary = "웨이팅 등록")
+    @ApiResponse(responseCode = "201", description = "웨이팅 등록 성공")
+    @PostMapping("/api/v1/stores/{storeId}/waiting")
+    ResponseEntity<WaitingTicketResponse> register(
+            @PathVariable Long storeId,
+            @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId,
+            @RequestBody WaitingRegisterRequest request
+    );
+
+    @Operation(summary = "웨이팅 취소")
+    @ApiResponse(responseCode = "204", description = "웨이팅 취소 성공")
+    @DeleteMapping("/api/v1/waiting/{ticketId}")
+    ResponseEntity<Void> cancel(
+            @PathVariable Long ticketId,
+            @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId
+    );
+
+    @Operation(summary = "다음 순번 호출")
+    @ApiResponse(responseCode = "200", description = "호출 성공")
+    @PostMapping("/api/v1/stores/{storeId}/waiting/call-next")
+    ResponseEntity<WaitingTicketResponse> callNext(@PathVariable Long storeId);
+
+    @Operation(summary = "착석 확인")
+    @ApiResponse(responseCode = "204", description = "착석 처리 성공")
+    @PatchMapping("/api/v1/waiting/{ticketId}/seated")
+    ResponseEntity<Void> confirmSeated(@PathVariable Long ticketId);
+
+    @Operation(summary = "노쇼 처리")
+    @ApiResponse(responseCode = "204", description = "노쇼 처리 성공")
+    @PatchMapping("/api/v1/waiting/{ticketId}/no-show")
+    ResponseEntity<Void> markNoShow(@PathVariable Long ticketId);
+}

--- a/src/main/java/com/intime/presentation/waiting/api/WaitingQueryApi.java
+++ b/src/main/java/com/intime/presentation/waiting/api/WaitingQueryApi.java
@@ -1,0 +1,33 @@
+package com.intime.presentation.waiting.api;
+
+import com.intime.application.waiting.WaitingPositionResponse;
+import com.intime.presentation.waiting.dto.WaitingTicketResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Waiting Query", description = "웨이팅 조회 관련 API")
+public interface WaitingQueryApi {
+
+    @Operation(summary = "가게 대기열 조회")
+    @ApiResponse(responseCode = "200", description = "대기열 조회 성공")
+    @GetMapping("/api/v1/stores/{storeId}/queue")
+    ResponseEntity<List<WaitingTicketResponse>> getStoreQueue(@PathVariable Long storeId);
+
+    @Operation(summary = "내 대기표 목록 조회")
+    @ApiResponse(responseCode = "200", description = "내 대기표 조회 성공")
+    @GetMapping("/api/v1/waiting/me")
+    ResponseEntity<List<WaitingTicketResponse>> getMyTickets(
+            @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId
+    );
+
+    @Operation(summary = "대기 순번 조회")
+    @ApiResponse(responseCode = "200", description = "순번 조회 성공")
+    @GetMapping("/api/v1/waiting/{ticketId}/position")
+    ResponseEntity<WaitingPositionResponse> getMyPosition(@PathVariable Long ticketId);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,12 @@ spring:
         format_sql: true
     open-in-view: false
 
+springdoc:
+  swagger-ui:
+    enabled: ${SWAGGER_ENABLED:true}
+  api-docs:
+    enabled: ${SWAGGER_ENABLED:true}
+
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
## 변경 사항 요약

springdoc-openapi 연동 + Controller 인터페이스 분리로 Swagger UI API 명세 제공

Closes #39

---

## 주요 변경 사항

### 1. Swagger 인프라

**SwaggerConfig**

- OpenAPI Bean 등록 (title: InTime API, version: v1)

### 2. Controller 인터페이스 분리

**presentation/{domain}/api/ (신규 7개)**

- `MemberApi`, `StoreApi`, `WaitingApi`, `WaitingQueryApi`, `TradePostApi`, `ExchangeRequestApi`, `NegotiationApi`
- `@Tag`, `@Operation`, `@ApiResponse` 어노테이션 전담

**Controller 7개**

- `implements XxxApi` 한 줄 추가 (기존 매핑/로직 무변경)

---

## 동작 흐름

```
Controller implements XxxApi
  -> Springdoc이 인터페이스의 @Operation/@Tag 스캔
  -> /v3/api-docs JSON 생성
  -> /swagger-ui/index.html 에서 렌더링
```

---

## 기술적 의사결정

### 왜 Controller 인터페이스 분리인가?

**문제**
- Swagger 어노테이션을 Controller에 직접 달면 운영 코드에 문서화 관심사가 섞임

**해결**
- `presentation/{domain}/api/XxxApi.java` 인터페이스에 Swagger 어노테이션 전담
- Controller는 `implements XxxApi` 한 줄만 추가, 기존 코드 무변경

**비교**
- Controller 직접 어노테이션: 구현 간단하지만 관심사 혼재

---

## 완료 항목

- [x] Swagger UI 접속으로 전체 API 목록 확인
- [x] 각 API의 요청/응답 스펙 문서화
- [x] Swagger 어노테이션을 Controller 인터페이스에 분리해 운영 코드 침범 방지
- [x] Try it out으로 API 직접 호출 테스트