### PR TITLE
[chore] 프론트엔드 연동을 위한 CORS 설정 추가

### DIFF
--- a/src/main/java/com/intime/config/WebConfig.java
+++ b/src/main/java/com/intime/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.intime.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${cors.allowed-origins:http://localhost:3000}")
+    private String allowedOrigins;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins(allowedOrigins.split(","))
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .exposedHeaders("X-Member-Id")
+                .maxAge(3600);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,9 @@ spring:
         format_sql: true
     open-in-view: false
 
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
+
 springdoc:
   swagger-ui:
     enabled: ${SWAGGER_ENABLED:true}


### PR DESCRIPTION
## 변경 사항 요약

프론트엔드 개발 서버 연동을 위한 CORS 전역 설정 추가

---

## 주요 변경 사항

- `WebConfig`: `/api/**` 경로 CORS 정책 적용, `X-Member-Id` 헤더 expose
- `application.yml`: `CORS_ALLOWED_ORIGINS` 환경변수로 오리진 외부 주입 (기본값: `http://localhost:3000`)

---

## 완료 항목

- [x] /api/** CORS 허용
- [x] 환경변수 기반 allowed-origins 설정