### PR TITLE
Controller-Service DTO 레이어 분리

### DIFF
--- a/src/main/java/com/intime/application/member/MemberService.java
+++ b/src/main/java/com/intime/application/member/MemberService.java
@@ -1,12 +1,13 @@
 package com.intime.application.member;
 
-import com.intime.domain.member.Member;
+import com.intime.application.member.dto.MemberInfo;
+import com.intime.application.member.dto.MemberSignupCommand;
 
 public interface MemberService {
 
-    Member signup(String email, String password);
+    MemberInfo signup(MemberSignupCommand command);
 
-    Member getMember(Long memberId);
+    MemberInfo getMember(Long memberId);
 
-    Member updateNickname(Long memberId, String nickname);
+    MemberInfo updateNickname(Long memberId, String nickname);
 }

--- a/src/main/java/com/intime/application/member/MemberServiceImpl.java
+++ b/src/main/java/com/intime/application/member/MemberServiceImpl.java
@@ -1,5 +1,7 @@
 package com.intime.application.member;
 
+import com.intime.application.member.dto.MemberInfo;
+import com.intime.application.member.dto.MemberSignupCommand;
 import com.intime.common.exception.BusinessException;
 import com.intime.domain.member.Member;
 import com.intime.domain.member.MemberCode;
@@ -19,26 +21,29 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
-    public Member signup(String email, String password) {
-        if (memberRepository.existsByEmail(email)) {
+    public MemberInfo signup(MemberSignupCommand command) {
+        if (memberRepository.existsByEmail(command.email())) {
             throw new BusinessException(MemberCode.MEMBER_EMAIL_DUPLICATE);
         }
         String nickname = generateNickname();
-        return memberRepository.save(Member.create(email, password, nickname));
+        Member member = memberRepository.save(Member.create(command.email(), command.password(), nickname));
+        return MemberInfo.from(member);
     }
 
     @Override
-    public Member getMember(Long memberId) {
-        return memberRepository.findById(memberId)
+    public MemberInfo getMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(MemberCode.MEMBER_NOT_FOUND));
+        return MemberInfo.from(member);
     }
 
     @Override
     @Transactional
-    public Member updateNickname(Long memberId, String nickname) {
-        Member member = getMember(memberId);
+    public MemberInfo updateNickname(Long memberId, String nickname) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(MemberCode.MEMBER_NOT_FOUND));
         member.updateNickname(nickname);
-        return member;
+        return MemberInfo.from(member);
     }
 
     private String generateNickname() {

--- a/src/main/java/com/intime/application/member/dto/MemberInfo.java
+++ b/src/main/java/com/intime/application/member/dto/MemberInfo.java
@@ -1,18 +1,18 @@
-package com.intime.presentation.member.dto;
+package com.intime.application.member.dto;
 
 import com.intime.domain.member.Member;
 
 import java.time.LocalDateTime;
 
-public record MemberResponse(
+public record MemberInfo(
         Long id,
         String email,
         String nickname,
         LocalDateTime createdAt
 ) {
 
-    public static MemberResponse from(Member member) {
-        return new MemberResponse(
+    public static MemberInfo from(Member member) {
+        return new MemberInfo(
                 member.getId(),
                 member.getEmail(),
                 member.getNickname(),

--- a/src/main/java/com/intime/application/member/dto/MemberSignupCommand.java
+++ b/src/main/java/com/intime/application/member/dto/MemberSignupCommand.java
@@ -1,0 +1,7 @@
+package com.intime.application.member.dto;
+
+public record MemberSignupCommand(
+        String email,
+        String password
+) {
+}

--- a/src/main/java/com/intime/application/negotiation/NegotiationService.java
+++ b/src/main/java/com/intime/application/negotiation/NegotiationService.java
@@ -1,18 +1,20 @@
 package com.intime.application.negotiation;
 
-import com.intime.domain.negotiation.Negotiation;
+import com.intime.application.negotiation.dto.NegotiationFinalOfferCommand;
+import com.intime.application.negotiation.dto.NegotiationInfo;
+import com.intime.application.negotiation.dto.NegotiationOfferCommand;
 
 public interface NegotiationService {
 
-    Negotiation getNegotiation(Long negotiationId);
+    NegotiationInfo getNegotiation(Long negotiationId);
 
-    Negotiation getNegotiationByExchangeRequestId(Long exchangeRequestId);
+    NegotiationInfo getNegotiationByExchangeRequestId(Long exchangeRequestId);
 
-    Negotiation makeOffer(Long negotiationId, Long memberId, Long price);
+    NegotiationInfo makeOffer(NegotiationOfferCommand command);
 
     void accept(Long negotiationId, Long memberId);
 
     void reject(Long negotiationId, Long memberId);
 
-    void submitFinalOffer(Long negotiationId, Long memberId, Long price);
+    void submitFinalOffer(NegotiationFinalOfferCommand command);
 }

--- a/src/main/java/com/intime/application/negotiation/NegotiationServiceImpl.java
+++ b/src/main/java/com/intime/application/negotiation/NegotiationServiceImpl.java
@@ -1,5 +1,8 @@
 package com.intime.application.negotiation;
 
+import com.intime.application.negotiation.dto.NegotiationFinalOfferCommand;
+import com.intime.application.negotiation.dto.NegotiationInfo;
+import com.intime.application.negotiation.dto.NegotiationOfferCommand;
 import com.intime.application.trade.TradeLifecycleService;
 import com.intime.application.waiting.WaitingEventPublisher;
 import com.intime.common.exception.BusinessException;
@@ -42,33 +45,36 @@ public class NegotiationServiceImpl implements NegotiationService {
     private final Clock clock;
 
     @Override
-    public Negotiation getNegotiation(Long negotiationId) {
-        return getNegotiationOrThrow(negotiationId);
+    public NegotiationInfo getNegotiation(Long negotiationId) {
+        return NegotiationInfo.from(getNegotiationOrThrow(negotiationId));
     }
 
     @Override
-    public Negotiation getNegotiationByExchangeRequestId(Long exchangeRequestId) {
-        return negotiationRepository.findByExchangeRequestId(exchangeRequestId)
+    public NegotiationInfo getNegotiationByExchangeRequestId(Long exchangeRequestId) {
+        Negotiation negotiation = negotiationRepository.findByExchangeRequestId(exchangeRequestId)
                 .orElseThrow(() -> new BusinessException(NegotiationCode.NEGOTIATION_NOT_FOUND));
+        return NegotiationInfo.from(negotiation);
     }
 
     @Override
     @Transactional
-    public Negotiation makeOffer(Long negotiationId, Long memberId, Long price) {
-        Negotiation negotiation = getNegotiationOrThrow(negotiationId);
-        negotiation.makeOffer(memberId, price);
+    public NegotiationInfo makeOffer(NegotiationOfferCommand command) {
+        Negotiation negotiation = getNegotiationOrThrow(command.negotiationId());
+        negotiation.makeOffer(command.memberId(), command.price());
         log.info("가격 제안 - negotiationId: {}, memberId: {}, price: {}, offerCount: {}, status: {}",
-                negotiationId, memberId, price, negotiation.getOfferCount(), negotiation.getStatus());
+                command.negotiationId(), command.memberId(), command.price(),
+                negotiation.getOfferCount(), negotiation.getStatus());
 
         if (negotiation.getStatus() == NegotiationStatus.FINAL_ROUND) {
-            eventPublisher.publish(negotiationId,
+            eventPublisher.publish(command.negotiationId(),
                     NegotiationEventDto.ofFinalRound(negotiation.getExpiresAt(), negotiation.getLastOfferedBy()));
         } else {
-            eventPublisher.publish(negotiationId,
-                    NegotiationEventDto.ofOffer(price, negotiation.getOfferCount(), negotiation.getExpiresAt(), negotiation.getLastOfferedBy()));
+            eventPublisher.publish(command.negotiationId(),
+                    NegotiationEventDto.ofOffer(command.price(), negotiation.getOfferCount(),
+                            negotiation.getExpiresAt(), negotiation.getLastOfferedBy()));
         }
 
-        return negotiation;
+        return NegotiationInfo.from(negotiation);
     }
 
     @Override
@@ -113,8 +119,8 @@ public class NegotiationServiceImpl implements NegotiationService {
 
     @Override
     @Transactional
-    public void submitFinalOffer(Long negotiationId, Long memberId, Long price) {
-        Negotiation negotiation = getNegotiationOrThrow(negotiationId);
+    public void submitFinalOffer(NegotiationFinalOfferCommand command) {
+        Negotiation negotiation = getNegotiationOrThrow(command.negotiationId());
 
         WaitingTicket sellerTicket = getTicket(negotiation.getSellerTicketId());
         if (!sellerTicket.isTradeable()) {
@@ -126,18 +132,17 @@ public class NegotiationServiceImpl implements NegotiationService {
             throw new BusinessException(NegotiationCode.BUYER_TICKET_NOT_TRADEABLE);
         }
 
-        boolean dealReached = negotiation.submitFinalOffer(memberId, price);
-        log.info("최종가 제출 - negotiationId: {}, memberId: {}, price: {}, dealReached: {}", negotiationId, memberId, price, dealReached);
+        boolean dealReached = negotiation.submitFinalOffer(command.memberId(), command.price());
+        log.info("최종가 제출 - negotiationId: {}, memberId: {}, price: {}, dealReached: {}",
+                command.negotiationId(), command.memberId(), command.price(), dealReached);
 
         if (dealReached) {
             executeDeal(negotiation, sellerTicket);
         } else if (negotiation.getStatus() == NegotiationStatus.FAILED) {
-            // 양쪽 모두 제출했지만 가격 불일치 → 협상 불성사
-            log.info("최종 입찰 가격 불일치 → 협상 불성사 - negotiationId: {}", negotiationId);
-            eventPublisher.publish(negotiationId, NegotiationEventDto.ofFailed());
+            log.info("최종 입찰 가격 불일치 → 협상 불성사 - negotiationId: {}", command.negotiationId());
+            eventPublisher.publish(command.negotiationId(), NegotiationEventDto.ofFailed());
         } else {
-            // 한쪽만 제출한 상태 → 상대방에게 제출 요청 알림
-            eventPublisher.publish(negotiationId, NegotiationEventDto.ofFinalOfferSubmitted());
+            eventPublisher.publish(command.negotiationId(), NegotiationEventDto.ofFinalOfferSubmitted());
         }
     }
 

--- a/src/main/java/com/intime/application/negotiation/dto/NegotiationFinalOfferCommand.java
+++ b/src/main/java/com/intime/application/negotiation/dto/NegotiationFinalOfferCommand.java
@@ -1,0 +1,8 @@
+package com.intime.application.negotiation.dto;
+
+public record NegotiationFinalOfferCommand(
+        Long negotiationId,
+        Long memberId,
+        Long price
+) {
+}

--- a/src/main/java/com/intime/application/negotiation/dto/NegotiationInfo.java
+++ b/src/main/java/com/intime/application/negotiation/dto/NegotiationInfo.java
@@ -1,11 +1,11 @@
-package com.intime.presentation.negotiation.dto;
+package com.intime.application.negotiation.dto;
 
 import com.intime.domain.negotiation.Negotiation;
 import com.intime.domain.negotiation.NegotiationStatus;
 
 import java.time.LocalDateTime;
 
-public record NegotiationResponse(
+public record NegotiationInfo(
         Long id,
         NegotiationStatus status,
         Long currentPrice,
@@ -15,8 +15,9 @@ public record NegotiationResponse(
         Long sellerId,
         Long buyerId
 ) {
-    public static NegotiationResponse from(Negotiation negotiation) {
-        return new NegotiationResponse(
+
+    public static NegotiationInfo from(Negotiation negotiation) {
+        return new NegotiationInfo(
                 negotiation.getId(),
                 negotiation.getStatus(),
                 negotiation.getCurrentPrice(),

--- a/src/main/java/com/intime/application/negotiation/dto/NegotiationOfferCommand.java
+++ b/src/main/java/com/intime/application/negotiation/dto/NegotiationOfferCommand.java
@@ -1,0 +1,8 @@
+package com.intime.application.negotiation.dto;
+
+public record NegotiationOfferCommand(
+        Long negotiationId,
+        Long memberId,
+        Long price
+) {
+}

--- a/src/main/java/com/intime/application/store/StoreService.java
+++ b/src/main/java/com/intime/application/store/StoreService.java
@@ -1,14 +1,15 @@
 package com.intime.application.store;
 
-import com.intime.domain.store.Store;
+import com.intime.application.store.dto.StoreCreateCommand;
+import com.intime.application.store.dto.StoreInfo;
 
 import java.util.List;
 
 public interface StoreService {
 
-    Store createStore(String name, String address, int estimatedWaitMinutes);
+    StoreInfo createStore(StoreCreateCommand command);
 
-    Store getStore(Long storeId);
+    StoreInfo getStore(Long storeId);
 
-    List<Store> getStores();
+    List<StoreInfo> getStores();
 }

--- a/src/main/java/com/intime/application/store/StoreServiceImpl.java
+++ b/src/main/java/com/intime/application/store/StoreServiceImpl.java
@@ -1,5 +1,7 @@
 package com.intime.application.store;
 
+import com.intime.application.store.dto.StoreCreateCommand;
+import com.intime.application.store.dto.StoreInfo;
 import com.intime.common.exception.BusinessException;
 import com.intime.domain.store.Store;
 import com.intime.domain.store.StoreCode;
@@ -19,18 +21,23 @@ public class StoreServiceImpl implements StoreService {
 
     @Override
     @Transactional
-    public Store createStore(String name, String address, int estimatedWaitMinutes) {
-        return storeRepository.save(Store.create(name, address, estimatedWaitMinutes));
+    public StoreInfo createStore(StoreCreateCommand command) {
+        Store store = storeRepository.save(
+                Store.create(command.name(), command.address(), command.estimatedWaitMinutes()));
+        return StoreInfo.from(store);
     }
 
     @Override
-    public Store getStore(Long storeId) {
-        return storeRepository.findById(storeId)
+    public StoreInfo getStore(Long storeId) {
+        Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new BusinessException(StoreCode.STORE_NOT_FOUND));
+        return StoreInfo.from(store);
     }
 
     @Override
-    public List<Store> getStores() {
-        return storeRepository.findAll();
+    public List<StoreInfo> getStores() {
+        return storeRepository.findAll().stream()
+                .map(StoreInfo::from)
+                .toList();
     }
 }

--- a/src/main/java/com/intime/application/store/dto/StoreCreateCommand.java
+++ b/src/main/java/com/intime/application/store/dto/StoreCreateCommand.java
@@ -1,0 +1,8 @@
+package com.intime.application.store.dto;
+
+public record StoreCreateCommand(
+        String name,
+        String address,
+        int estimatedWaitMinutes
+) {
+}

--- a/src/main/java/com/intime/application/store/dto/StoreInfo.java
+++ b/src/main/java/com/intime/application/store/dto/StoreInfo.java
@@ -1,16 +1,16 @@
-package com.intime.presentation.store.dto;
+package com.intime.application.store.dto;
 
 import com.intime.domain.store.Store;
 
-public record StoreResponse(
+public record StoreInfo(
         Long id,
         String name,
         String address,
         int estimatedWaitMinutes
 ) {
 
-    public static StoreResponse from(Store store) {
-        return new StoreResponse(
+    public static StoreInfo from(Store store) {
+        return new StoreInfo(
                 store.getId(),
                 store.getName(),
                 store.getAddress(),

--- a/src/main/java/com/intime/application/trade/ExchangeRequestService.java
+++ b/src/main/java/com/intime/application/trade/ExchangeRequestService.java
@@ -1,17 +1,19 @@
 package com.intime.application.trade;
 
-import com.intime.domain.trade.ExchangeRequest;
+import com.intime.application.trade.dto.ExchangeRequestCommand;
+import com.intime.application.trade.dto.ExchangeRequestInfo;
 
 import java.util.List;
 
 public interface ExchangeRequestService {
-    ExchangeRequest requestExchange(Long postId, Long buyerTicketId, Long buyerId, Long offerPrice);
+
+    ExchangeRequestInfo requestExchange(ExchangeRequestCommand command);
 
     void cancelRequest(Long requestId, Long buyerId);
 
     void selectBuyerAndStartNegotiation(Long requestId, Long sellerId);
 
-    List<ExchangeRequest> getPostRequests(Long postId);
+    List<ExchangeRequestInfo> getPostRequests(Long postId);
 
-    List<ExchangeRequest> getMyRequests(Long buyerId);
+    List<ExchangeRequestInfo> getMyRequests(Long buyerId);
 }

--- a/src/main/java/com/intime/application/trade/ExchangeRequestServiceImpl.java
+++ b/src/main/java/com/intime/application/trade/ExchangeRequestServiceImpl.java
@@ -1,5 +1,7 @@
 package com.intime.application.trade;
 
+import com.intime.application.trade.dto.ExchangeRequestCommand;
+import com.intime.application.trade.dto.ExchangeRequestInfo;
 import com.intime.common.exception.BusinessException;
 import com.intime.domain.negotiation.Negotiation;
 import com.intime.domain.negotiation.NegotiationRepository;
@@ -34,27 +36,28 @@ public class ExchangeRequestServiceImpl implements ExchangeRequestService {
 
     @Override
     @Transactional
-    public ExchangeRequest requestExchange(Long postId, Long buyerTicketId, Long buyerId, Long offerPrice) {
-        TradePost post = getPost(postId);
+    public ExchangeRequestInfo requestExchange(ExchangeRequestCommand command) {
+        TradePost post = getPost(command.postId());
 
         if (post.getStatus() != TradePostStatus.OPEN) {
             throw new BusinessException(TradePostCode.TRADE_POST_INVALID_STATE);
         }
 
-        if (post.isOwnedBy(buyerId)) {
+        if (post.isOwnedBy(command.buyerId())) {
             throw new BusinessException(ExchangeRequestCode.EXCHANGE_REQUEST_SELF_POST);
         }
 
         boolean isDuplicate = exchangeRequestRepository.existsByTradePostIdAndBuyerIdAndStatusIn(
-                postId, buyerId, List.of(ExchangeRequestStatus.PENDING, ExchangeRequestStatus.SELECTED));
+                command.postId(), command.buyerId(),
+                List.of(ExchangeRequestStatus.PENDING, ExchangeRequestStatus.SELECTED));
         if (isDuplicate) {
             throw new BusinessException(ExchangeRequestCode.EXCHANGE_REQUEST_DUPLICATE);
         }
 
-        WaitingTicket buyerTicket = waitingTicketRepository.findById(buyerTicketId)
+        WaitingTicket buyerTicket = waitingTicketRepository.findById(command.buyerTicketId())
                 .orElseThrow(() -> new BusinessException(WaitingCode.WAITING_NOT_FOUND));
 
-        if (!buyerTicket.isOwnedBy(buyerId)) {
+        if (!buyerTicket.isOwnedBy(command.buyerId())) {
             throw new BusinessException(ExchangeRequestCode.BUYER_TICKET_NOT_OWNER);
         }
 
@@ -63,11 +66,13 @@ public class ExchangeRequestServiceImpl implements ExchangeRequestService {
         }
 
         LocalDateTime expiresAt = LocalDateTime.now(clock).plusMinutes(REQUEST_TTL_MINUTES);
-        ExchangeRequest request = ExchangeRequest.create(postId, buyerTicketId, buyerId, offerPrice, expiresAt);
+        ExchangeRequest request = ExchangeRequest.create(
+                command.postId(), command.buyerTicketId(), command.buyerId(), command.offerPrice(), expiresAt);
         ExchangeRequest saved = exchangeRequestRepository.save(request);
-        log.info("교환 신청 완료 - postId: {}, buyerId: {}, buyerTicketId: {}, offerPrice: {}", postId, buyerId, buyerTicketId, offerPrice);
-        tradePostEventPublisher.publishNewRequest(postId, offerPrice);
-        return saved;
+        log.info("교환 신청 완료 - postId: {}, buyerId: {}, buyerTicketId: {}, offerPrice: {}",
+                command.postId(), command.buyerId(), command.buyerTicketId(), command.offerPrice());
+        tradePostEventPublisher.publishNewRequest(command.postId(), command.offerPrice());
+        return ExchangeRequestInfo.from(saved);
     }
 
     @Override
@@ -97,8 +102,7 @@ public class ExchangeRequestServiceImpl implements ExchangeRequestService {
 
         selectedRequest.select();
         post.startNegotiation();
-
-        // 구매자의 offerPrice를 offer 1로 삼아 협상 자동 시작
+        
         Negotiation negotiation = Negotiation.create(
                 selectedRequest.getId(),
                 sellerId,
@@ -109,17 +113,22 @@ public class ExchangeRequestServiceImpl implements ExchangeRequestService {
                 clock
         );
         negotiationRepository.save(negotiation);
-        log.info("구매자 선택 + 협상 시작 - requestId: {}, sellerId: {}, buyerId: {}", requestId, sellerId, selectedRequest.getBuyerId());
+        log.info("구매자 선택 + 협상 시작 - requestId: {}, sellerId: {}, buyerId: {}",
+                requestId, sellerId, selectedRequest.getBuyerId());
     }
 
     @Override
-    public List<ExchangeRequest> getPostRequests(Long postId) {
-        return exchangeRequestRepository.findByTradePostId(postId);
+    public List<ExchangeRequestInfo> getPostRequests(Long postId) {
+        return exchangeRequestRepository.findByTradePostId(postId).stream()
+                .map(ExchangeRequestInfo::from)
+                .toList();
     }
 
     @Override
-    public List<ExchangeRequest> getMyRequests(Long buyerId) {
-        return exchangeRequestRepository.findByBuyerIdOrderByCreatedAtDesc(buyerId);
+    public List<ExchangeRequestInfo> getMyRequests(Long buyerId) {
+        return exchangeRequestRepository.findByBuyerIdOrderByCreatedAtDesc(buyerId).stream()
+                .map(ExchangeRequestInfo::from)
+                .toList();
     }
 
     private TradePost getPost(Long postId) {

--- a/src/main/java/com/intime/application/trade/TradePostService.java
+++ b/src/main/java/com/intime/application/trade/TradePostService.java
@@ -1,17 +1,17 @@
 package com.intime.application.trade;
 
-import com.intime.domain.trade.TradePost;
+import com.intime.application.trade.dto.TradePostInfo;
+import com.intime.application.trade.dto.TradePostRegisterCommand;
 
 import java.util.List;
 
 public interface TradePostService {
-    TradePost register(Long ticketId, Long sellerId, Long price);
+
+    TradePostInfo register(TradePostRegisterCommand command);
 
     void withdraw(Long postId, Long sellerId);
 
-    List<TradePost> getStoreTradePosts(Long storeId);
+    List<TradePostInfo> getStoreTradePosts(Long storeId);
 
-    List<TradePost> getMyTradePosts(Long sellerId);
-
-    List<TradePost> getOpenPostsByTicketIds(List<Long> ticketIds);
+    List<TradePostInfo> getMyTradePosts(Long sellerId);
 }

--- a/src/main/java/com/intime/application/trade/TradePostServiceImpl.java
+++ b/src/main/java/com/intime/application/trade/TradePostServiceImpl.java
@@ -1,11 +1,13 @@
 package com.intime.application.trade;
 
+import com.intime.application.trade.dto.TradePostInfo;
+import com.intime.application.trade.dto.TradePostRegisterCommand;
 import com.intime.common.exception.BusinessException;
 import com.intime.domain.trade.*;
+import com.intime.domain.waiting.WaitingCode;
 import com.intime.domain.waiting.WaitingStatus;
 import com.intime.domain.waiting.WaitingTicket;
 import com.intime.domain.waiting.WaitingTicketRepository;
-import com.intime.domain.waiting.WaitingCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,11 +28,11 @@ public class TradePostServiceImpl implements TradePostService {
 
     @Override
     @Transactional
-    public TradePost register(Long ticketId, Long sellerId, Long price) {
-        WaitingTicket ticket = waitingTicketRepository.findById(ticketId)
+    public TradePostInfo register(TradePostRegisterCommand command) {
+        WaitingTicket ticket = waitingTicketRepository.findById(command.ticketId())
                 .orElseThrow(() -> new BusinessException(WaitingCode.WAITING_NOT_FOUND));
 
-        if (!ticket.isOwnedBy(sellerId)) {
+        if (!ticket.isOwnedBy(command.sellerId())) {
             throw new BusinessException(TradePostCode.TRADE_POST_NOT_OWNER);
         }
 
@@ -38,14 +40,15 @@ public class TradePostServiceImpl implements TradePostService {
             throw new BusinessException(TradePostCode.TICKET_NOT_TRADEABLE);
         }
 
-        if (tradePostRepository.existsByWaitingTicketIdAndStatus(ticketId, TradePostStatus.OPEN)) {
+        if (tradePostRepository.existsByWaitingTicketIdAndStatus(command.ticketId(), TradePostStatus.OPEN)) {
             throw new BusinessException(TradePostCode.TRADE_POST_DUPLICATE);
         }
 
-        TradePost post = TradePost.create(ticketId, sellerId, ticket.getStoreId(), price);
+        TradePost post = TradePost.create(command.ticketId(), command.sellerId(), ticket.getStoreId(), command.price());
         TradePost saved = tradePostRepository.save(post);
-        log.info("판매 게시글 등록 - ticketId: {}, sellerId: {}, price: {}", ticketId, sellerId, price);
-        return saved;
+        log.info("판매 게시글 등록 - ticketId: {}, sellerId: {}, price: {}",
+                command.ticketId(), command.sellerId(), command.price());
+        return TradePostInfo.from(saved);
     }
 
     @Override
@@ -59,7 +62,7 @@ public class TradePostServiceImpl implements TradePostService {
             throw new BusinessException(TradePostCode.TRADE_POST_INVALID_STATE);
         }
         post.cancel();
-        tradePostRepository.saveAndFlush(post); // @Modifying clearAutomatically 이전에 flush 보장
+        tradePostRepository.saveAndFlush(post);
         exchangeRequestRepository.cancelAllPendingByTradePostId(
                 postId, ExchangeRequestStatus.PENDING, ExchangeRequestStatus.CANCELLED);
         tradePostEventPublisher.publishPostCancelled(postId);
@@ -67,21 +70,17 @@ public class TradePostServiceImpl implements TradePostService {
     }
 
     @Override
-    public List<TradePost> getStoreTradePosts(Long storeId) {
-        return tradePostRepository.findByStoreIdAndStatus(storeId, TradePostStatus.OPEN);
+    public List<TradePostInfo> getStoreTradePosts(Long storeId) {
+        return tradePostRepository.findByStoreIdAndStatus(storeId, TradePostStatus.OPEN).stream()
+                .map(TradePostInfo::from)
+                .toList();
     }
 
     @Override
-    public List<TradePost> getMyTradePosts(Long sellerId) {
-        return tradePostRepository.findBySellerIdOrderByCreatedAtDesc(sellerId);
-    }
-
-    @Override
-    public List<TradePost> getOpenPostsByTicketIds(List<Long> ticketIds) {
-        if (ticketIds.isEmpty()) {
-            return List.of();
-        }
-        return tradePostRepository.findByWaitingTicketIdInAndStatus(ticketIds, TradePostStatus.OPEN);
+    public List<TradePostInfo> getMyTradePosts(Long sellerId) {
+        return tradePostRepository.findBySellerIdOrderByCreatedAtDesc(sellerId).stream()
+                .map(TradePostInfo::from)
+                .toList();
     }
 
     private TradePost getPost(Long postId) {

--- a/src/main/java/com/intime/application/trade/dto/ExchangeRequestCommand.java
+++ b/src/main/java/com/intime/application/trade/dto/ExchangeRequestCommand.java
@@ -1,0 +1,9 @@
+package com.intime.application.trade.dto;
+
+public record ExchangeRequestCommand(
+        Long postId,
+        Long buyerTicketId,
+        Long buyerId,
+        Long offerPrice
+) {
+}

--- a/src/main/java/com/intime/application/trade/dto/ExchangeRequestInfo.java
+++ b/src/main/java/com/intime/application/trade/dto/ExchangeRequestInfo.java
@@ -1,11 +1,11 @@
-package com.intime.presentation.trade.dto;
+package com.intime.application.trade.dto;
 
 import com.intime.domain.trade.ExchangeRequest;
 import com.intime.domain.trade.ExchangeRequestStatus;
 
 import java.time.LocalDateTime;
 
-public record ExchangeRequestResponse(
+public record ExchangeRequestInfo(
         Long id,
         Long tradePostId,
         Long buyerTicketId,
@@ -15,8 +15,9 @@ public record ExchangeRequestResponse(
         LocalDateTime expiresAt,
         LocalDateTime createdAt
 ) {
-    public static ExchangeRequestResponse from(ExchangeRequest request) {
-        return new ExchangeRequestResponse(
+
+    public static ExchangeRequestInfo from(ExchangeRequest request) {
+        return new ExchangeRequestInfo(
                 request.getId(),
                 request.getTradePostId(),
                 request.getBuyerTicketId(),

--- a/src/main/java/com/intime/application/trade/dto/TradePostInfo.java
+++ b/src/main/java/com/intime/application/trade/dto/TradePostInfo.java
@@ -1,11 +1,11 @@
-package com.intime.presentation.trade.dto;
+package com.intime.application.trade.dto;
 
 import com.intime.domain.trade.TradePost;
 import com.intime.domain.trade.TradePostStatus;
 
 import java.time.LocalDateTime;
 
-public record TradePostResponse(
+public record TradePostInfo(
         Long id,
         Long waitingTicketId,
         Long sellerId,
@@ -14,8 +14,9 @@ public record TradePostResponse(
         Long price,
         LocalDateTime createdAt
 ) {
-    public static TradePostResponse from(TradePost post) {
-        return new TradePostResponse(
+
+    public static TradePostInfo from(TradePost post) {
+        return new TradePostInfo(
                 post.getId(),
                 post.getWaitingTicketId(),
                 post.getSellerId(),

--- a/src/main/java/com/intime/application/trade/dto/TradePostRegisterCommand.java
+++ b/src/main/java/com/intime/application/trade/dto/TradePostRegisterCommand.java
@@ -1,0 +1,8 @@
+package com.intime.application.trade.dto;
+
+public record TradePostRegisterCommand(
+        Long ticketId,
+        Long sellerId,
+        Long price
+) {
+}

--- a/src/main/java/com/intime/application/waiting/WaitingQueryService.java
+++ b/src/main/java/com/intime/application/waiting/WaitingQueryService.java
@@ -1,14 +1,15 @@
 package com.intime.application.waiting;
 
-import com.intime.domain.waiting.WaitingTicket;
+import com.intime.application.waiting.dto.WaitingPositionInfo;
+import com.intime.application.waiting.dto.WaitingTicketInfo;
 
 import java.util.List;
 
 public interface WaitingQueryService {
 
-    List<WaitingTicket> getStoreQueue(Long storeId);
+    List<WaitingTicketInfo> getStoreQueue(Long storeId);
 
-    List<WaitingTicket> getMyTickets(Long memberId);
+    List<WaitingTicketInfo> getMyTickets(Long memberId);
 
-    WaitingPositionResponse getMyPosition(Long ticketId);
+    WaitingPositionInfo getMyPosition(Long ticketId);
 }

--- a/src/main/java/com/intime/application/waiting/WaitingQueryServiceImpl.java
+++ b/src/main/java/com/intime/application/waiting/WaitingQueryServiceImpl.java
@@ -1,13 +1,21 @@
 package com.intime.application.waiting;
 
+import com.intime.application.waiting.dto.WaitingPositionInfo;
+import com.intime.application.waiting.dto.WaitingTicketInfo;
+import com.intime.application.waiting.dto.WaitingTicketInfo.TradePostSummary;
 import com.intime.common.exception.BusinessException;
 import com.intime.domain.store.StoreRepository;
+import com.intime.domain.trade.TradePost;
+import com.intime.domain.trade.TradePostRepository;
+import com.intime.domain.trade.TradePostStatus;
 import com.intime.domain.waiting.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.intime.domain.store.StoreCode.STORE_NOT_FOUND;
 
@@ -18,21 +26,46 @@ public class WaitingQueryServiceImpl implements WaitingQueryService {
 
     private final WaitingTicketRepository waitingTicketRepository;
     private final StoreRepository storeRepository;
+    private final TradePostRepository tradePostRepository;
 
     @Override
-    public List<WaitingTicket> getStoreQueue(Long storeId) {
-        return waitingTicketRepository.findByStoreIdAndStatusInOrderByPositionNumberAsc(
+    public List<WaitingTicketInfo> getStoreQueue(Long storeId) {
+        List<WaitingTicket> tickets = waitingTicketRepository.findByStoreIdAndStatusInOrderByPositionNumberAsc(
                 storeId, List.of(WaitingStatus.WAITING, WaitingStatus.CALLED));
+
+        Map<Long, TradePostSummary> tradePostByTicketId =
+                tradePostRepository.findByStoreIdAndStatus(storeId, TradePostStatus.OPEN).stream()
+                        .collect(Collectors.toMap(
+                                TradePost::getWaitingTicketId,
+                                tp -> new TradePostSummary(tp.getId(), tp.getPrice())
+                        ));
+
+        return tickets.stream()
+                .map(ticket -> WaitingTicketInfo.from(ticket, tradePostByTicketId.get(ticket.getId())))
+                .toList();
     }
 
     @Override
-    public List<WaitingTicket> getMyTickets(Long memberId) {
-        return waitingTicketRepository.findByMemberIdAndStatusIn(
+    public List<WaitingTicketInfo> getMyTickets(Long memberId) {
+        List<WaitingTicket> tickets = waitingTicketRepository.findByMemberIdAndStatusIn(
                 memberId, List.of(WaitingStatus.WAITING, WaitingStatus.CALLED));
+
+        List<Long> ticketIds = tickets.stream().map(WaitingTicket::getId).toList();
+        Map<Long, TradePostSummary> tradePostByTicketId = ticketIds.isEmpty()
+                ? Map.of()
+                : tradePostRepository.findByWaitingTicketIdInAndStatus(ticketIds, TradePostStatus.OPEN).stream()
+                        .collect(Collectors.toMap(
+                                TradePost::getWaitingTicketId,
+                                tp -> new TradePostSummary(tp.getId(), tp.getPrice())
+                        ));
+
+        return tickets.stream()
+                .map(ticket -> WaitingTicketInfo.from(ticket, tradePostByTicketId.get(ticket.getId())))
+                .toList();
     }
 
     @Override
-    public WaitingPositionResponse getMyPosition(Long ticketId) {
+    public WaitingPositionInfo getMyPosition(Long ticketId) {
         WaitingTicket ticket = waitingTicketRepository.findById(ticketId)
                 .orElseThrow(() -> new BusinessException(WaitingCode.WAITING_NOT_FOUND));
 
@@ -47,7 +80,7 @@ public class WaitingQueryServiceImpl implements WaitingQueryService {
                 .orElseThrow(() -> new BusinessException(STORE_NOT_FOUND))
                 .getEstimatedWaitMinutes() * aheadCount;
 
-        return new WaitingPositionResponse(
+        return new WaitingPositionInfo(
                 ticket.getId(),
                 ticket.getPositionNumber(),
                 aheadCount,

--- a/src/main/java/com/intime/application/waiting/WaitingService.java
+++ b/src/main/java/com/intime/application/waiting/WaitingService.java
@@ -1,14 +1,15 @@
 package com.intime.application.waiting;
 
-import com.intime.domain.waiting.WaitingTicket;
+import com.intime.application.waiting.dto.WaitingRegisterCommand;
+import com.intime.application.waiting.dto.WaitingTicketInfo;
 
 public interface WaitingService {
 
-    WaitingTicket register(Long storeId, Long memberId, int partySize);
+    WaitingTicketInfo register(WaitingRegisterCommand command);
 
     void cancel(Long ticketId, Long memberId);
 
-    WaitingTicket callNext(Long storeId);
+    WaitingTicketInfo callNext(Long storeId);
 
     void confirmSeated(Long ticketId);
 

--- a/src/main/java/com/intime/application/waiting/WaitingServiceImpl.java
+++ b/src/main/java/com/intime/application/waiting/WaitingServiceImpl.java
@@ -1,6 +1,8 @@
 package com.intime.application.waiting;
 
 import com.intime.application.trade.TradePostEventPublisher;
+import com.intime.application.waiting.dto.WaitingRegisterCommand;
+import com.intime.application.waiting.dto.WaitingTicketInfo;
 import com.intime.common.exception.BusinessException;
 import com.intime.domain.negotiation.NegotiationRepository;
 import com.intime.domain.negotiation.NegotiationStatus;
@@ -41,28 +43,31 @@ public class WaitingServiceImpl implements WaitingService {
     @Transactional
     @Retryable(retryFor = ObjectOptimisticLockingFailureException.class,
             maxAttempts = 3, backoff = @Backoff(delay = 100))
-    public WaitingTicket register(Long storeId, Long memberId, int partySize) {
+    public WaitingTicketInfo register(WaitingRegisterCommand command) {
         LocalDate today = LocalDate.now(clock);
 
         boolean isDuplicate = waitingTicketRepository.existsByMemberIdAndStoreIdAndWaitingDateAndStatusIn(
-                memberId, storeId, today, List.of(WaitingStatus.WAITING, WaitingStatus.CALLED));
+                command.memberId(), command.storeId(), today, List.of(WaitingStatus.WAITING, WaitingStatus.CALLED));
         if (isDuplicate) {
             throw new BusinessException(WaitingCode.WAITING_DUPLICATE);
         }
 
         int nextPosition = waitingTicketRepository
-                .findTopByStoreIdAndWaitingDateOrderByPositionNumberDesc(storeId, today)
+                .findTopByStoreIdAndWaitingDateOrderByPositionNumberDesc(command.storeId(), today)
                 .map(ticket -> ticket.getPositionNumber() + 1)
                 .orElse(1);
 
-        WaitingTicket ticket = WaitingTicket.create(storeId, memberId, nextPosition, partySize, today);
+        WaitingTicket ticket = WaitingTicket.create(
+                command.storeId(), command.memberId(), nextPosition, command.partySize(), today);
 
         try {
             WaitingTicket saved = waitingTicketRepository.save(ticket);
-            log.info("웨이팅 등록 완료 - storeId: {}, memberId: {}, positionNumber: {}", storeId, memberId, nextPosition);
-            return saved;
+            log.info("웨이팅 등록 완료 - storeId: {}, memberId: {}, positionNumber: {}",
+                    command.storeId(), command.memberId(), nextPosition);
+            return WaitingTicketInfo.from(saved);
         } catch (DataIntegrityViolationException e) {
-            log.warn("웨이팅 등록 실패 (순번 충돌) - storeId: {}, memberId: {}", storeId, memberId);
+            log.warn("웨이팅 등록 실패 (순번 충돌) - storeId: {}, memberId: {}",
+                    command.storeId(), command.memberId());
             throw new BusinessException(WaitingCode.WAITING_REGISTER_FAILED);
         }
     }
@@ -80,21 +85,20 @@ public class WaitingServiceImpl implements WaitingService {
 
         ticket.cancel();
 
-        waitingTicketRepository.saveAndFlush(ticket); // @Modifying clearAutomatically 이전에 flush 보장
+        waitingTicketRepository.saveAndFlush(ticket);
         log.info("웨이팅 취소 - ticketId: {}, memberId: {}", ticketId, memberId);
 
         // 판매자로서 게시한 교환 게시글 취소 → 구매자 신청 일괄 취소 + 알림
         tradePostRepository.findByWaitingTicketIdAndStatus(ticket.getId(), TradePostStatus.OPEN)
                 .ifPresent(post -> {
                     post.cancel();
-                    tradePostRepository.saveAndFlush(post); // @Modifying clearAutomatically 이전에 flush 보장
+                    tradePostRepository.saveAndFlush(post);
                     exchangeRequestRepository.cancelAllPendingByTradePostId(
                             post.getId(), ExchangeRequestStatus.PENDING, ExchangeRequestStatus.CANCELLED);
                     tradePostEventPublisher.publishPostCancelled(post.getId());
                     log.info("웨이팅 취소로 인한 판매 게시글 취소 - postId: {}", post.getId());
                 });
 
-        // 구매자로서 신청한 교환 신청 취소
         int cancelledCount = exchangeRequestRepository.cancelAllPendingByBuyerTicketId(
                 ticketId, ExchangeRequestStatus.PENDING, ExchangeRequestStatus.CANCELLED);
         if (cancelledCount > 0) {
@@ -106,7 +110,7 @@ public class WaitingServiceImpl implements WaitingService {
     @Transactional
     @Retryable(retryFor = ObjectOptimisticLockingFailureException.class,
             maxAttempts = 3, backoff = @Backoff(delay = 100))
-    public WaitingTicket callNext(Long storeId) {
+    public WaitingTicketInfo callNext(Long storeId) {
         WaitingTicket ticket = waitingTicketRepository
                 .findTopByStoreIdAndStatusOrderByPositionNumberAsc(storeId, WaitingStatus.WAITING)
                 .orElseThrow(() -> new BusinessException(WaitingCode.WAITING_NO_ONE_WAITING));
@@ -127,10 +131,11 @@ public class WaitingServiceImpl implements WaitingService {
         } else {
             ticket.call(now);
             waitingEventPublisher.publishCalled(ticket.getId());
-            log.info("순번 호출 - storeId: {}, ticketId: {}, positionNumber: {}", storeId, ticket.getId(), ticket.getPositionNumber());
+            log.info("순번 호출 - storeId: {}, ticketId: {}, positionNumber: {}",
+                    storeId, ticket.getId(), ticket.getPositionNumber());
         }
 
-        return ticket;
+        return WaitingTicketInfo.from(ticket);
     }
 
     @Override

--- a/src/main/java/com/intime/application/waiting/dto/WaitingPositionInfo.java
+++ b/src/main/java/com/intime/application/waiting/dto/WaitingPositionInfo.java
@@ -1,6 +1,6 @@
-package com.intime.application.waiting;
+package com.intime.application.waiting.dto;
 
-public record WaitingPositionResponse(
+public record WaitingPositionInfo(
         Long ticketId,
         int positionNumber,
         int aheadCount,

--- a/src/main/java/com/intime/application/waiting/dto/WaitingRegisterCommand.java
+++ b/src/main/java/com/intime/application/waiting/dto/WaitingRegisterCommand.java
@@ -1,0 +1,8 @@
+package com.intime.application.waiting.dto;
+
+public record WaitingRegisterCommand(
+        Long storeId,
+        Long memberId,
+        int partySize
+) {
+}

--- a/src/main/java/com/intime/application/waiting/dto/WaitingTicketInfo.java
+++ b/src/main/java/com/intime/application/waiting/dto/WaitingTicketInfo.java
@@ -1,11 +1,11 @@
-package com.intime.presentation.waiting.dto;
+package com.intime.application.waiting.dto;
 
 import com.intime.domain.waiting.WaitingStatus;
 import com.intime.domain.waiting.WaitingTicket;
 
 import java.time.LocalDate;
 
-public record WaitingTicketResponse(
+public record WaitingTicketInfo(
         Long id,
         Long storeId,
         Long memberId,
@@ -13,17 +13,18 @@ public record WaitingTicketResponse(
         WaitingStatus status,
         int partySize,
         LocalDate waitingDate,
-        TradePostInfo tradePost
+        TradePostSummary tradePost
 ) {
 
-    public record TradePostInfo(Long tradePostId, Long price) {}
+    public record TradePostSummary(Long tradePostId, Long price) {
+    }
 
-    public static WaitingTicketResponse from(WaitingTicket ticket) {
+    public static WaitingTicketInfo from(WaitingTicket ticket) {
         return from(ticket, null);
     }
 
-    public static WaitingTicketResponse from(WaitingTicket ticket, TradePostInfo tradePost) {
-        return new WaitingTicketResponse(
+    public static WaitingTicketInfo from(WaitingTicket ticket, TradePostSummary tradePost) {
+        return new WaitingTicketInfo(
                 ticket.getId(),
                 ticket.getStoreId(),
                 ticket.getMemberId(),

--- a/src/main/java/com/intime/domain/negotiation/Negotiation.java
+++ b/src/main/java/com/intime/domain/negotiation/Negotiation.java
@@ -18,7 +18,6 @@ import java.time.LocalDateTime;
         name = "negotiation",
         uniqueConstraints = @UniqueConstraint(columnNames = "exchange_request_id"),
         indexes = {
-                @Index(name = "idx_negotiation_exchange_request", columnList = "exchange_request_id"),
                 @Index(name = "idx_negotiation_seller_ticket_status", columnList = "seller_ticket_id, status"),
                 @Index(name = "idx_negotiation_status_expires", columnList = "status, expires_at")
         }

--- a/src/main/java/com/intime/domain/trade/ExchangeRequest.java
+++ b/src/main/java/com/intime/domain/trade/ExchangeRequest.java
@@ -16,7 +16,9 @@ import java.time.LocalDateTime;
 @Table(
         name = "exchange_request",
         indexes = {
-                @Index(name = "idx_exchange_request_trade_post", columnList = "trade_post_id"),
+                @Index(name = "idx_exchange_request_trade_post_status", columnList = "trade_post_id, status"),
+                @Index(name = "idx_exchange_request_buyer_ticket_status", columnList = "buyer_ticket_id, status"),
+                @Index(name = "idx_exchange_request_buyer_id", columnList = "buyer_id"),
                 @Index(name = "idx_exchange_request_status_expires", columnList = "status, expires_at")
         }
 )

--- a/src/main/java/com/intime/presentation/member/MemberController.java
+++ b/src/main/java/com/intime/presentation/member/MemberController.java
@@ -1,11 +1,11 @@
 package com.intime.presentation.member;
 
 import com.intime.application.member.MemberService;
-import com.intime.domain.member.Member;
-import com.intime.presentation.member.dto.MemberResponse;
+import com.intime.application.member.dto.MemberInfo;
+import com.intime.application.member.dto.MemberSignupCommand;
+import com.intime.presentation.member.api.MemberApi;
 import com.intime.presentation.member.dto.NicknameUpdateRequest;
 import com.intime.presentation.member.dto.SignupRequest;
-import com.intime.presentation.member.api.MemberApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,21 +19,21 @@ public class MemberController implements MemberApi {
     private final MemberService memberService;
 
     @PostMapping("/signup")
-    public ResponseEntity<MemberResponse> signup(@RequestBody SignupRequest request) {
-        Member member = memberService.signup(request.email(), request.password());
-        return ResponseEntity.status(HttpStatus.CREATED).body(MemberResponse.from(member));
+    public ResponseEntity<MemberInfo> signup(@RequestBody SignupRequest request) {
+        MemberSignupCommand command = new MemberSignupCommand(request.email(), request.password());
+        return ResponseEntity.status(HttpStatus.CREATED).body(memberService.signup(command));
     }
 
     @GetMapping("/{memberId}")
-    public ResponseEntity<MemberResponse> getMember(@PathVariable Long memberId) {
-        return ResponseEntity.ok(MemberResponse.from(memberService.getMember(memberId)));
+    public ResponseEntity<MemberInfo> getMember(@PathVariable Long memberId) {
+        return ResponseEntity.ok(memberService.getMember(memberId));
     }
 
     @PatchMapping("/{memberId}")
-    public ResponseEntity<MemberResponse> updateNickname(
+    public ResponseEntity<MemberInfo> updateNickname(
             @PathVariable Long memberId,
             @RequestBody NicknameUpdateRequest request
     ) {
-        return ResponseEntity.ok(MemberResponse.from(memberService.updateNickname(memberId, request.nickname())));
+        return ResponseEntity.ok(memberService.updateNickname(memberId, request.nickname()));
     }
 }

--- a/src/main/java/com/intime/presentation/member/api/MemberApi.java
+++ b/src/main/java/com/intime/presentation/member/api/MemberApi.java
@@ -1,6 +1,6 @@
 package com.intime.presentation.member.api;
 
-import com.intime.presentation.member.dto.MemberResponse;
+import com.intime.application.member.dto.MemberInfo;
 import com.intime.presentation.member.dto.NicknameUpdateRequest;
 import com.intime.presentation.member.dto.SignupRequest;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,17 +16,17 @@ public interface MemberApi {
     @Operation(summary = "회원가입")
     @ApiResponse(responseCode = "201", description = "회원가입 성공")
     @PostMapping("/signup")
-    ResponseEntity<MemberResponse> signup(@RequestBody SignupRequest request);
+    ResponseEntity<MemberInfo> signup(@RequestBody SignupRequest request);
 
     @Operation(summary = "회원 조회")
     @ApiResponse(responseCode = "200", description = "회원 조회 성공")
     @GetMapping("/{memberId}")
-    ResponseEntity<MemberResponse> getMember(@PathVariable Long memberId);
+    ResponseEntity<MemberInfo> getMember(@PathVariable Long memberId);
 
     @Operation(summary = "닉네임 수정")
     @ApiResponse(responseCode = "200", description = "닉네임 수정 성공")
     @PatchMapping("/{memberId}")
-    ResponseEntity<MemberResponse> updateNickname(
+    ResponseEntity<MemberInfo> updateNickname(
             @PathVariable Long memberId,
             @RequestBody NicknameUpdateRequest request
     );

--- a/src/main/java/com/intime/presentation/negotiation/NegotiationController.java
+++ b/src/main/java/com/intime/presentation/negotiation/NegotiationController.java
@@ -1,11 +1,12 @@
 package com.intime.presentation.negotiation;
 
 import com.intime.application.negotiation.NegotiationService;
-import com.intime.domain.negotiation.Negotiation;
+import com.intime.application.negotiation.dto.NegotiationFinalOfferCommand;
+import com.intime.application.negotiation.dto.NegotiationInfo;
+import com.intime.application.negotiation.dto.NegotiationOfferCommand;
+import com.intime.presentation.negotiation.api.NegotiationApi;
 import com.intime.presentation.negotiation.dto.NegotiationFinalOfferRequest;
 import com.intime.presentation.negotiation.dto.NegotiationOfferRequest;
-import com.intime.presentation.negotiation.dto.NegotiationResponse;
-import com.intime.presentation.negotiation.api.NegotiationApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,13 +18,13 @@ public class NegotiationController implements NegotiationApi {
     private final NegotiationService negotiationService;
 
     @PostMapping("/api/v1/negotiations/{negotiationId}/offers")
-    public ResponseEntity<NegotiationResponse> makeOffer(
+    public ResponseEntity<NegotiationInfo> makeOffer(
             @PathVariable Long negotiationId,
             @RequestHeader("X-Member-Id") Long memberId,
             @RequestBody NegotiationOfferRequest request
     ) {
-        Negotiation negotiation = negotiationService.makeOffer(negotiationId, memberId, request.price());
-        return ResponseEntity.ok(NegotiationResponse.from(negotiation));
+        NegotiationOfferCommand command = new NegotiationOfferCommand(negotiationId, memberId, request.price());
+        return ResponseEntity.ok(negotiationService.makeOffer(command));
     }
 
     @PostMapping("/api/v1/negotiations/{negotiationId}/accept")
@@ -50,19 +51,18 @@ public class NegotiationController implements NegotiationApi {
             @RequestHeader("X-Member-Id") Long memberId,
             @RequestBody NegotiationFinalOfferRequest request
     ) {
-        negotiationService.submitFinalOffer(negotiationId, memberId, request.price());
+        NegotiationFinalOfferCommand command = new NegotiationFinalOfferCommand(negotiationId, memberId, request.price());
+        negotiationService.submitFinalOffer(command);
         return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/api/v1/negotiations/{negotiationId}")
-    public ResponseEntity<NegotiationResponse> getNegotiation(@PathVariable Long negotiationId) {
-        Negotiation negotiation = negotiationService.getNegotiation(negotiationId);
-        return ResponseEntity.ok(NegotiationResponse.from(negotiation));
+    public ResponseEntity<NegotiationInfo> getNegotiation(@PathVariable Long negotiationId) {
+        return ResponseEntity.ok(negotiationService.getNegotiation(negotiationId));
     }
 
     @GetMapping("/api/v1/exchange-requests/{requestId}/negotiation")
-    public ResponseEntity<NegotiationResponse> getNegotiationByExchangeRequestId(@PathVariable Long requestId) {
-        Negotiation negotiation = negotiationService.getNegotiationByExchangeRequestId(requestId);
-        return ResponseEntity.ok(NegotiationResponse.from(negotiation));
+    public ResponseEntity<NegotiationInfo> getNegotiationByExchangeRequestId(@PathVariable Long requestId) {
+        return ResponseEntity.ok(negotiationService.getNegotiationByExchangeRequestId(requestId));
     }
 }

--- a/src/main/java/com/intime/presentation/negotiation/api/NegotiationApi.java
+++ b/src/main/java/com/intime/presentation/negotiation/api/NegotiationApi.java
@@ -1,8 +1,8 @@
 package com.intime.presentation.negotiation.api;
 
+import com.intime.application.negotiation.dto.NegotiationInfo;
 import com.intime.presentation.negotiation.dto.NegotiationFinalOfferRequest;
 import com.intime.presentation.negotiation.dto.NegotiationOfferRequest;
-import com.intime.presentation.negotiation.dto.NegotiationResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -16,7 +16,7 @@ public interface NegotiationApi {
     @Operation(summary = "오퍼 제시")
     @ApiResponse(responseCode = "200", description = "오퍼 제시 성공")
     @PostMapping("/api/v1/negotiations/{negotiationId}/offers")
-    ResponseEntity<NegotiationResponse> makeOffer(
+    ResponseEntity<NegotiationInfo> makeOffer(
             @PathVariable Long negotiationId,
             @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId,
             @RequestBody NegotiationOfferRequest request
@@ -50,10 +50,10 @@ public interface NegotiationApi {
     @Operation(summary = "협상 조회")
     @ApiResponse(responseCode = "200", description = "협상 조회 성공")
     @GetMapping("/api/v1/negotiations/{negotiationId}")
-    ResponseEntity<NegotiationResponse> getNegotiation(@PathVariable Long negotiationId);
+    ResponseEntity<NegotiationInfo> getNegotiation(@PathVariable Long negotiationId);
 
     @Operation(summary = "교환 신청으로 협상 조회")
     @ApiResponse(responseCode = "200", description = "협상 조회 성공")
     @GetMapping("/api/v1/exchange-requests/{requestId}/negotiation")
-    ResponseEntity<NegotiationResponse> getNegotiationByExchangeRequestId(@PathVariable Long requestId);
+    ResponseEntity<NegotiationInfo> getNegotiationByExchangeRequestId(@PathVariable Long requestId);
 }

--- a/src/main/java/com/intime/presentation/store/StoreController.java
+++ b/src/main/java/com/intime/presentation/store/StoreController.java
@@ -1,10 +1,10 @@
 package com.intime.presentation.store;
 
 import com.intime.application.store.StoreService;
-import com.intime.domain.store.Store;
-import com.intime.presentation.store.dto.StoreCreateRequest;
-import com.intime.presentation.store.dto.StoreResponse;
+import com.intime.application.store.dto.StoreCreateCommand;
+import com.intime.application.store.dto.StoreInfo;
 import com.intime.presentation.store.api.StoreApi;
+import com.intime.presentation.store.dto.StoreCreateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,20 +20,19 @@ public class StoreController implements StoreApi {
     private final StoreService storeService;
 
     @PostMapping
-    public ResponseEntity<StoreResponse> createStore(@RequestBody StoreCreateRequest request) {
-        Store store = storeService.createStore(request.name(), request.address(), request.estimatedWaitMinutes());
-        return ResponseEntity.status(HttpStatus.CREATED).body(StoreResponse.from(store));
+    public ResponseEntity<StoreInfo> createStore(@RequestBody StoreCreateRequest request) {
+        StoreCreateCommand command = new StoreCreateCommand(
+                request.name(), request.address(), request.estimatedWaitMinutes());
+        return ResponseEntity.status(HttpStatus.CREATED).body(storeService.createStore(command));
     }
 
     @GetMapping
-    public ResponseEntity<List<StoreResponse>> getStores() {
-        return ResponseEntity.ok(storeService.getStores().stream()
-                .map(StoreResponse::from)
-                .toList());
+    public ResponseEntity<List<StoreInfo>> getStores() {
+        return ResponseEntity.ok(storeService.getStores());
     }
 
     @GetMapping("/{storeId}")
-    public ResponseEntity<StoreResponse> getStore(@PathVariable Long storeId) {
-        return ResponseEntity.ok(StoreResponse.from(storeService.getStore(storeId)));
+    public ResponseEntity<StoreInfo> getStore(@PathVariable Long storeId) {
+        return ResponseEntity.ok(storeService.getStore(storeId));
     }
 }

--- a/src/main/java/com/intime/presentation/store/api/StoreApi.java
+++ b/src/main/java/com/intime/presentation/store/api/StoreApi.java
@@ -1,7 +1,7 @@
 package com.intime.presentation.store.api;
 
+import com.intime.application.store.dto.StoreInfo;
 import com.intime.presentation.store.dto.StoreCreateRequest;
-import com.intime.presentation.store.dto.StoreResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,15 +17,15 @@ public interface StoreApi {
     @Operation(summary = "가게 등록")
     @ApiResponse(responseCode = "201", description = "가게 등록 성공")
     @PostMapping
-    ResponseEntity<StoreResponse> createStore(@RequestBody StoreCreateRequest request);
+    ResponseEntity<StoreInfo> createStore(@RequestBody StoreCreateRequest request);
 
     @Operation(summary = "가게 목록 조회")
     @ApiResponse(responseCode = "200", description = "가게 목록 조회 성공")
     @GetMapping
-    ResponseEntity<List<StoreResponse>> getStores();
+    ResponseEntity<List<StoreInfo>> getStores();
 
     @Operation(summary = "가게 단건 조회")
     @ApiResponse(responseCode = "200", description = "가게 단건 조회 성공")
     @GetMapping("/{storeId}")
-    ResponseEntity<StoreResponse> getStore(@PathVariable Long storeId);
+    ResponseEntity<StoreInfo> getStore(@PathVariable Long storeId);
 }

--- a/src/main/java/com/intime/presentation/trade/ExchangeRequestController.java
+++ b/src/main/java/com/intime/presentation/trade/ExchangeRequestController.java
@@ -1,10 +1,10 @@
 package com.intime.presentation.trade;
 
 import com.intime.application.trade.ExchangeRequestService;
-import com.intime.domain.trade.ExchangeRequest;
-import com.intime.presentation.trade.dto.ExchangeRequestCreateRequest;
-import com.intime.presentation.trade.dto.ExchangeRequestResponse;
+import com.intime.application.trade.dto.ExchangeRequestCommand;
+import com.intime.application.trade.dto.ExchangeRequestInfo;
 import com.intime.presentation.trade.api.ExchangeRequestApi;
+import com.intime.presentation.trade.dto.ExchangeRequestCreateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,13 +19,14 @@ public class ExchangeRequestController implements ExchangeRequestApi {
     private final ExchangeRequestService exchangeRequestService;
 
     @PostMapping("/api/v1/trade-posts/{postId}/requests")
-    public ResponseEntity<ExchangeRequestResponse> requestExchange(
+    public ResponseEntity<ExchangeRequestInfo> requestExchange(
             @PathVariable Long postId,
             @RequestHeader("X-Member-Id") Long memberId,
             @RequestBody ExchangeRequestCreateRequest request
     ) {
-        ExchangeRequest exchangeRequest = exchangeRequestService.requestExchange(postId, request.buyerTicketId(), memberId, request.offerPrice());
-        return ResponseEntity.status(HttpStatus.CREATED).body(ExchangeRequestResponse.from(exchangeRequest));
+        ExchangeRequestCommand command = new ExchangeRequestCommand(
+                postId, request.buyerTicketId(), memberId, request.offerPrice());
+        return ResponseEntity.status(HttpStatus.CREATED).body(exchangeRequestService.requestExchange(command));
     }
 
     @DeleteMapping("/api/v1/exchange-requests/{requestId}")
@@ -38,10 +39,8 @@ public class ExchangeRequestController implements ExchangeRequestApi {
     }
 
     @GetMapping("/api/v1/trade-posts/{postId}/requests")
-    public ResponseEntity<List<ExchangeRequestResponse>> getRequests(@PathVariable Long postId) {
-        return ResponseEntity.ok(exchangeRequestService.getPostRequests(postId).stream()
-                .map(ExchangeRequestResponse::from)
-                .toList());
+    public ResponseEntity<List<ExchangeRequestInfo>> getRequests(@PathVariable Long postId) {
+        return ResponseEntity.ok(exchangeRequestService.getPostRequests(postId));
     }
 
     @PostMapping("/api/v1/exchange-requests/{requestId}/select")
@@ -54,11 +53,9 @@ public class ExchangeRequestController implements ExchangeRequestApi {
     }
 
     @GetMapping("/api/v1/exchange-requests/my")
-    public ResponseEntity<List<ExchangeRequestResponse>> getMyRequests(
+    public ResponseEntity<List<ExchangeRequestInfo>> getMyRequests(
             @RequestHeader("X-Member-Id") Long memberId
     ) {
-        return ResponseEntity.ok(exchangeRequestService.getMyRequests(memberId).stream()
-                .map(ExchangeRequestResponse::from)
-                .toList());
+        return ResponseEntity.ok(exchangeRequestService.getMyRequests(memberId));
     }
 }

--- a/src/main/java/com/intime/presentation/trade/TradePostController.java
+++ b/src/main/java/com/intime/presentation/trade/TradePostController.java
@@ -1,10 +1,10 @@
 package com.intime.presentation.trade;
 
 import com.intime.application.trade.TradePostService;
-import com.intime.domain.trade.TradePost;
-import com.intime.presentation.trade.dto.TradePostCreateRequest;
-import com.intime.presentation.trade.dto.TradePostResponse;
+import com.intime.application.trade.dto.TradePostInfo;
+import com.intime.application.trade.dto.TradePostRegisterCommand;
 import com.intime.presentation.trade.api.TradePostApi;
+import com.intime.presentation.trade.dto.TradePostCreateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,13 +19,13 @@ public class TradePostController implements TradePostApi {
     private final TradePostService tradePostService;
 
     @PostMapping("/api/v1/waiting/{ticketId}/trade-post")
-    public ResponseEntity<TradePostResponse> register(
+    public ResponseEntity<TradePostInfo> register(
             @PathVariable Long ticketId,
             @RequestHeader("X-Member-Id") Long memberId,
             @RequestBody TradePostCreateRequest request
     ) {
-        TradePost post = tradePostService.register(ticketId, memberId, request.price());
-        return ResponseEntity.status(HttpStatus.CREATED).body(TradePostResponse.from(post));
+        TradePostRegisterCommand command = new TradePostRegisterCommand(ticketId, memberId, request.price());
+        return ResponseEntity.status(HttpStatus.CREATED).body(tradePostService.register(command));
     }
 
     @DeleteMapping("/api/v1/trade-posts/{postId}")
@@ -38,18 +38,14 @@ public class TradePostController implements TradePostApi {
     }
 
     @GetMapping("/api/v1/stores/{storeId}/trade-posts")
-    public ResponseEntity<List<TradePostResponse>> getStoreTradePosts(@PathVariable Long storeId) {
-        return ResponseEntity.ok(tradePostService.getStoreTradePosts(storeId).stream()
-                .map(TradePostResponse::from)
-                .toList());
+    public ResponseEntity<List<TradePostInfo>> getStoreTradePosts(@PathVariable Long storeId) {
+        return ResponseEntity.ok(tradePostService.getStoreTradePosts(storeId));
     }
 
     @GetMapping("/api/v1/trade-posts/my")
-    public ResponseEntity<List<TradePostResponse>> getMyTradePosts(
+    public ResponseEntity<List<TradePostInfo>> getMyTradePosts(
             @RequestHeader("X-Member-Id") Long memberId
     ) {
-        return ResponseEntity.ok(tradePostService.getMyTradePosts(memberId).stream()
-                .map(TradePostResponse::from)
-                .toList());
+        return ResponseEntity.ok(tradePostService.getMyTradePosts(memberId));
     }
 }

--- a/src/main/java/com/intime/presentation/trade/api/ExchangeRequestApi.java
+++ b/src/main/java/com/intime/presentation/trade/api/ExchangeRequestApi.java
@@ -1,7 +1,7 @@
 package com.intime.presentation.trade.api;
 
+import com.intime.application.trade.dto.ExchangeRequestInfo;
 import com.intime.presentation.trade.dto.ExchangeRequestCreateRequest;
-import com.intime.presentation.trade.dto.ExchangeRequestResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -17,7 +17,7 @@ public interface ExchangeRequestApi {
     @Operation(summary = "순번 교환 신청")
     @ApiResponse(responseCode = "201", description = "교환 신청 성공")
     @PostMapping("/api/v1/trade-posts/{postId}/requests")
-    ResponseEntity<ExchangeRequestResponse> requestExchange(
+    ResponseEntity<ExchangeRequestInfo> requestExchange(
             @PathVariable Long postId,
             @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId,
             @RequestBody ExchangeRequestCreateRequest request
@@ -34,7 +34,7 @@ public interface ExchangeRequestApi {
     @Operation(summary = "게시글 교환 신청 목록 조회")
     @ApiResponse(responseCode = "200", description = "신청 목록 조회 성공")
     @GetMapping("/api/v1/trade-posts/{postId}/requests")
-    ResponseEntity<List<ExchangeRequestResponse>> getRequests(@PathVariable Long postId);
+    ResponseEntity<List<ExchangeRequestInfo>> getRequests(@PathVariable Long postId);
 
     @Operation(summary = "구매자 선택 (협상 자동 시작)")
     @ApiResponse(responseCode = "204", description = "구매자 선택 성공")
@@ -47,7 +47,7 @@ public interface ExchangeRequestApi {
     @Operation(summary = "내 교환 신청 목록 조회")
     @ApiResponse(responseCode = "200", description = "내 교환 신청 목록 조회 성공")
     @GetMapping("/api/v1/exchange-requests/my")
-    ResponseEntity<List<ExchangeRequestResponse>> getMyRequests(
+    ResponseEntity<List<ExchangeRequestInfo>> getMyRequests(
             @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId
     );
 }

--- a/src/main/java/com/intime/presentation/trade/api/TradePostApi.java
+++ b/src/main/java/com/intime/presentation/trade/api/TradePostApi.java
@@ -1,7 +1,7 @@
 package com.intime.presentation.trade.api;
 
+import com.intime.application.trade.dto.TradePostInfo;
 import com.intime.presentation.trade.dto.TradePostCreateRequest;
-import com.intime.presentation.trade.dto.TradePostResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -17,7 +17,7 @@ public interface TradePostApi {
     @Operation(summary = "순번 교환 게시글 등록")
     @ApiResponse(responseCode = "201", description = "게시글 등록 성공")
     @PostMapping("/api/v1/waiting/{ticketId}/trade-post")
-    ResponseEntity<TradePostResponse> register(
+    ResponseEntity<TradePostInfo> register(
             @PathVariable Long ticketId,
             @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId,
             @RequestBody TradePostCreateRequest request
@@ -34,12 +34,12 @@ public interface TradePostApi {
     @Operation(summary = "가게 교환 게시글 목록 조회")
     @ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공")
     @GetMapping("/api/v1/stores/{storeId}/trade-posts")
-    ResponseEntity<List<TradePostResponse>> getStoreTradePosts(@PathVariable Long storeId);
+    ResponseEntity<List<TradePostInfo>> getStoreTradePosts(@PathVariable Long storeId);
 
     @Operation(summary = "내 판매 게시글 목록 조회")
     @ApiResponse(responseCode = "200", description = "내 게시글 목록 조회 성공")
     @GetMapping("/api/v1/trade-posts/my")
-    ResponseEntity<List<TradePostResponse>> getMyTradePosts(
+    ResponseEntity<List<TradePostInfo>> getMyTradePosts(
             @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId
     );
 }

--- a/src/main/java/com/intime/presentation/waiting/WaitingController.java
+++ b/src/main/java/com/intime/presentation/waiting/WaitingController.java
@@ -1,10 +1,10 @@
 package com.intime.presentation.waiting;
 
 import com.intime.application.waiting.WaitingService;
-import com.intime.domain.waiting.WaitingTicket;
-import com.intime.presentation.waiting.dto.WaitingRegisterRequest;
-import com.intime.presentation.waiting.dto.WaitingTicketResponse;
+import com.intime.application.waiting.dto.WaitingRegisterCommand;
+import com.intime.application.waiting.dto.WaitingTicketInfo;
 import com.intime.presentation.waiting.api.WaitingApi;
+import com.intime.presentation.waiting.dto.WaitingRegisterRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,13 +17,13 @@ public class WaitingController implements WaitingApi {
     private final WaitingService waitingService;
 
     @PostMapping("/api/v1/stores/{storeId}/waiting")
-    public ResponseEntity<WaitingTicketResponse> register(
+    public ResponseEntity<WaitingTicketInfo> register(
             @PathVariable Long storeId,
             @RequestHeader("X-Member-Id") Long memberId,
             @RequestBody WaitingRegisterRequest request
     ) {
-        WaitingTicket ticket = waitingService.register(storeId, memberId, request.partySize());
-        return ResponseEntity.status(HttpStatus.CREATED).body(WaitingTicketResponse.from(ticket));
+        WaitingRegisterCommand command = new WaitingRegisterCommand(storeId, memberId, request.partySize());
+        return ResponseEntity.status(HttpStatus.CREATED).body(waitingService.register(command));
     }
 
     @DeleteMapping("/api/v1/waiting/{ticketId}")
@@ -36,9 +36,8 @@ public class WaitingController implements WaitingApi {
     }
 
     @PostMapping("/api/v1/stores/{storeId}/waiting/call-next")
-    public ResponseEntity<WaitingTicketResponse> callNext(@PathVariable Long storeId) {
-        WaitingTicket ticket = waitingService.callNext(storeId);
-        return ResponseEntity.ok(WaitingTicketResponse.from(ticket));
+    public ResponseEntity<WaitingTicketInfo> callNext(@PathVariable Long storeId) {
+        return ResponseEntity.ok(waitingService.callNext(storeId));
     }
 
     @PatchMapping("/api/v1/waiting/{ticketId}/seated")

--- a/src/main/java/com/intime/presentation/waiting/WaitingQueryController.java
+++ b/src/main/java/com/intime/presentation/waiting/WaitingQueryController.java
@@ -1,63 +1,35 @@
 package com.intime.presentation.waiting;
 
-import com.intime.application.trade.TradePostService;
-import com.intime.application.waiting.WaitingPositionResponse;
 import com.intime.application.waiting.WaitingQueryService;
-import com.intime.domain.trade.TradePost;
-import com.intime.domain.waiting.WaitingTicket;
-import com.intime.presentation.waiting.dto.WaitingTicketResponse;
-import com.intime.presentation.waiting.dto.WaitingTicketResponse.TradePostInfo;
+import com.intime.application.waiting.dto.WaitingPositionInfo;
+import com.intime.application.waiting.dto.WaitingTicketInfo;
 import com.intime.presentation.waiting.api.WaitingQueryApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
 public class WaitingQueryController implements WaitingQueryApi {
 
     private final WaitingQueryService waitingQueryService;
-    private final TradePostService tradePostService;
 
     @GetMapping("/api/v1/stores/{storeId}/queue")
-    public ResponseEntity<List<WaitingTicketResponse>> getStoreQueue(@PathVariable Long storeId) {
-        List<WaitingTicket> tickets = waitingQueryService.getStoreQueue(storeId);
-
-        Map<Long, TradePostInfo> tradePostByTicketId = tradePostService.getStoreTradePosts(storeId).stream()
-                .collect(Collectors.toMap(
-                        TradePost::getWaitingTicketId,
-                        tp -> new TradePostInfo(tp.getId(), tp.getPrice())
-                ));
-
-        return ResponseEntity.ok(tickets.stream()
-                .map(ticket -> WaitingTicketResponse.from(ticket, tradePostByTicketId.get(ticket.getId())))
-                .toList());
+    public ResponseEntity<List<WaitingTicketInfo>> getStoreQueue(@PathVariable Long storeId) {
+        return ResponseEntity.ok(waitingQueryService.getStoreQueue(storeId));
     }
 
     @GetMapping("/api/v1/waiting/me")
-    public ResponseEntity<List<WaitingTicketResponse>> getMyTickets(
+    public ResponseEntity<List<WaitingTicketInfo>> getMyTickets(
             @RequestHeader("X-Member-Id") Long memberId
     ) {
-        List<WaitingTicket> tickets = waitingQueryService.getMyTickets(memberId);
-
-        List<Long> ticketIds = tickets.stream().map(WaitingTicket::getId).toList();
-        Map<Long, TradePostInfo> tradePostByTicketId = tradePostService.getOpenPostsByTicketIds(ticketIds).stream()
-                .collect(Collectors.toMap(
-                        TradePost::getWaitingTicketId,
-                        tp -> new TradePostInfo(tp.getId(), tp.getPrice())
-                ));
-
-        return ResponseEntity.ok(tickets.stream()
-                .map(ticket -> WaitingTicketResponse.from(ticket, tradePostByTicketId.get(ticket.getId())))
-                .toList());
+        return ResponseEntity.ok(waitingQueryService.getMyTickets(memberId));
     }
 
     @GetMapping("/api/v1/waiting/{ticketId}/position")
-    public ResponseEntity<WaitingPositionResponse> getMyPosition(@PathVariable Long ticketId) {
+    public ResponseEntity<WaitingPositionInfo> getMyPosition(@PathVariable Long ticketId) {
         return ResponseEntity.ok(waitingQueryService.getMyPosition(ticketId));
     }
 }

--- a/src/main/java/com/intime/presentation/waiting/api/WaitingApi.java
+++ b/src/main/java/com/intime/presentation/waiting/api/WaitingApi.java
@@ -1,7 +1,7 @@
 package com.intime.presentation.waiting.api;
 
+import com.intime.application.waiting.dto.WaitingTicketInfo;
 import com.intime.presentation.waiting.dto.WaitingRegisterRequest;
-import com.intime.presentation.waiting.dto.WaitingTicketResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -15,7 +15,7 @@ public interface WaitingApi {
     @Operation(summary = "웨이팅 등록")
     @ApiResponse(responseCode = "201", description = "웨이팅 등록 성공")
     @PostMapping("/api/v1/stores/{storeId}/waiting")
-    ResponseEntity<WaitingTicketResponse> register(
+    ResponseEntity<WaitingTicketInfo> register(
             @PathVariable Long storeId,
             @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId,
             @RequestBody WaitingRegisterRequest request
@@ -32,7 +32,7 @@ public interface WaitingApi {
     @Operation(summary = "다음 순번 호출")
     @ApiResponse(responseCode = "200", description = "호출 성공")
     @PostMapping("/api/v1/stores/{storeId}/waiting/call-next")
-    ResponseEntity<WaitingTicketResponse> callNext(@PathVariable Long storeId);
+    ResponseEntity<WaitingTicketInfo> callNext(@PathVariable Long storeId);
 
     @Operation(summary = "착석 확인")
     @ApiResponse(responseCode = "204", description = "착석 처리 성공")

--- a/src/main/java/com/intime/presentation/waiting/api/WaitingQueryApi.java
+++ b/src/main/java/com/intime/presentation/waiting/api/WaitingQueryApi.java
@@ -1,7 +1,7 @@
 package com.intime.presentation.waiting.api;
 
-import com.intime.application.waiting.WaitingPositionResponse;
-import com.intime.presentation.waiting.dto.WaitingTicketResponse;
+import com.intime.application.waiting.dto.WaitingPositionInfo;
+import com.intime.application.waiting.dto.WaitingTicketInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -17,17 +17,17 @@ public interface WaitingQueryApi {
     @Operation(summary = "가게 대기열 조회")
     @ApiResponse(responseCode = "200", description = "대기열 조회 성공")
     @GetMapping("/api/v1/stores/{storeId}/queue")
-    ResponseEntity<List<WaitingTicketResponse>> getStoreQueue(@PathVariable Long storeId);
+    ResponseEntity<List<WaitingTicketInfo>> getStoreQueue(@PathVariable Long storeId);
 
     @Operation(summary = "내 대기표 목록 조회")
     @ApiResponse(responseCode = "200", description = "내 대기표 조회 성공")
     @GetMapping("/api/v1/waiting/me")
-    ResponseEntity<List<WaitingTicketResponse>> getMyTickets(
+    ResponseEntity<List<WaitingTicketInfo>> getMyTickets(
             @Parameter(description = "회원 ID") @RequestHeader("X-Member-Id") Long memberId
     );
 
     @Operation(summary = "대기 순번 조회")
     @ApiResponse(responseCode = "200", description = "순번 조회 성공")
     @GetMapping("/api/v1/waiting/{ticketId}/position")
-    ResponseEntity<WaitingPositionResponse> getMyPosition(@PathVariable Long ticketId);
+    ResponseEntity<WaitingPositionInfo> getMyPosition(@PathVariable Long ticketId);
 }

--- a/src/test/java/com/intime/application/member/MemberServiceTest.java
+++ b/src/test/java/com/intime/application/member/MemberServiceTest.java
@@ -1,5 +1,7 @@
 package com.intime.application.member;
 
+import com.intime.application.member.dto.MemberInfo;
+import com.intime.application.member.dto.MemberSignupCommand;
 import com.intime.common.exception.BusinessException;
 import com.intime.domain.member.Member;
 import com.intime.domain.member.MemberCode;
@@ -38,14 +40,15 @@ class MemberServiceTest {
         @DisplayName("성공 : 회원가입 시 '기다려' 접두사 닉네임이 생성된다")
         void signup() {
             // given
+            MemberSignupCommand command = new MemberSignupCommand("test@email.com", "password123");
             given(memberRepository.save(any(Member.class))).willAnswer(invocation -> invocation.getArgument(0));
 
             // when
-            Member result = memberService.signup("test@email.com", "password123");
+            MemberInfo result = memberService.signup(command);
 
             // then
-            assertThat(result.getEmail()).isEqualTo("test@email.com");
-            assertThat(result.getNickname()).startsWith("기다려");
+            assertThat(result.email()).isEqualTo("test@email.com");
+            assertThat(result.nickname()).startsWith("기다려");
         }
     }
 
@@ -61,10 +64,10 @@ class MemberServiceTest {
             given(memberRepository.findById(1L)).willReturn(Optional.of(member));
 
             // when
-            Member result = memberService.getMember(1L);
+            MemberInfo result = memberService.getMember(1L);
 
             // then
-            assertThat(result.getId()).isEqualTo(1L);
+            assertThat(result.id()).isEqualTo(1L);
         }
 
         @Test
@@ -93,10 +96,10 @@ class MemberServiceTest {
             given(memberRepository.findById(1L)).willReturn(Optional.of(member));
 
             // when
-            Member result = memberService.updateNickname(1L, "김철수");
+            MemberInfo result = memberService.updateNickname(1L, "김철수");
 
             // then
-            assertThat(result.getNickname()).isEqualTo("김철수");
+            assertThat(result.nickname()).isEqualTo("김철수");
         }
     }
 }

--- a/src/test/java/com/intime/application/negotiation/NegotiationServiceTest.java
+++ b/src/test/java/com/intime/application/negotiation/NegotiationServiceTest.java
@@ -1,5 +1,7 @@
 package com.intime.application.negotiation;
 
+import com.intime.application.negotiation.dto.NegotiationFinalOfferCommand;
+import com.intime.application.negotiation.dto.NegotiationOfferCommand;
 import com.intime.application.negotiation.fixture.NegotiationFixture;
 import com.intime.application.trade.TradeLifecycleService;
 import com.intime.application.trade.fixture.ExchangeRequestFixture;
@@ -79,7 +81,7 @@ class NegotiationServiceTest {
             given(negotiationRepository.findById(1L)).willReturn(Optional.of(negotiation));
 
             // when - seller(1L)이 카운터 오퍼 (lastOfferedBy=buyer(2L))
-            negotiationService.makeOffer(1L, 1L, 8000L);
+            negotiationService.makeOffer(new NegotiationOfferCommand(1L, 1L, 8000L));
 
             // then
             assertThat(negotiation.getCurrentPrice()).isEqualTo(8000L);
@@ -95,7 +97,7 @@ class NegotiationServiceTest {
             given(negotiationRepository.findById(1L)).willReturn(Optional.of(negotiation));
 
             // when & then
-            assertThatThrownBy(() -> negotiationService.makeOffer(1L, 2L, 9000L))
+            assertThatThrownBy(() -> negotiationService.makeOffer(new NegotiationOfferCommand(1L, 2L, 9000L)))
                     .isInstanceOf(BusinessException.class)
                     .extracting("baseCode")
                     .isEqualTo(NegotiationCode.NOT_YOUR_TURN);
@@ -109,7 +111,7 @@ class NegotiationServiceTest {
             given(negotiationRepository.findById(1L)).willReturn(Optional.of(negotiation));
 
             // when & then - FINAL_ROUND 상태에서 makeOffer 불가
-            assertThatThrownBy(() -> negotiationService.makeOffer(1L, 2L, 6500L))
+            assertThatThrownBy(() -> negotiationService.makeOffer(new NegotiationOfferCommand(1L, 2L, 6500L)))
                     .isInstanceOf(BusinessException.class)
                     .extracting("baseCode")
                     .isEqualTo(NegotiationCode.NEGOTIATION_INVALID_STATE);
@@ -124,7 +126,7 @@ class NegotiationServiceTest {
             given(negotiationRepository.findById(1L)).willReturn(Optional.of(negotiation));
 
             // when & then
-            assertThatThrownBy(() -> negotiationService.makeOffer(1L, 2L, 8000L))
+            assertThatThrownBy(() -> negotiationService.makeOffer(new NegotiationOfferCommand(1L, 2L, 8000L)))
                     .isInstanceOf(BusinessException.class)
                     .extracting("baseCode")
                     .isEqualTo(NegotiationCode.NEGOTIATION_INVALID_STATE);
@@ -230,10 +232,10 @@ class NegotiationServiceTest {
             given(exchangeRequestRepository.findById(1L)).willReturn(Optional.of(request));
             given(tradePostRepository.findById(1L)).willReturn(Optional.of(post));
 
-            negotiationService.submitFinalOffer(1L, 2L, 7000L); // 구매자 먼저 제출
+            negotiationService.submitFinalOffer(new NegotiationFinalOfferCommand(1L, 2L, 7000L)); // 구매자 먼저 제출
 
             // when - 판매자 6000 <= 구매자 7000 → 거래 성사 (sellerPrice로 체결)
-            negotiationService.submitFinalOffer(1L, 1L, 6000L);
+            negotiationService.submitFinalOffer(new NegotiationFinalOfferCommand(1L, 1L, 6000L));
 
             // then
             assertThat(negotiation.getStatus()).isEqualTo(NegotiationStatus.ACCEPTED);
@@ -254,10 +256,10 @@ class NegotiationServiceTest {
             given(waitingTicketRepository.findById(10L)).willReturn(Optional.of(sellerTicket));
             given(waitingTicketRepository.findById(20L)).willReturn(Optional.of(buyerTicket));
 
-            negotiationService.submitFinalOffer(1L, 2L, 5000L); // 구매자: 5000
+            negotiationService.submitFinalOffer(new NegotiationFinalOfferCommand(1L, 2L, 5000L)); // 구매자: 5000
 
             // when - 판매자 8000 > 구매자 5000 → 불성사
-            negotiationService.submitFinalOffer(1L, 1L, 8000L);
+            negotiationService.submitFinalOffer(new NegotiationFinalOfferCommand(1L, 1L, 8000L));
 
             // then
             assertThat(negotiation.getStatus()).isEqualTo(NegotiationStatus.FAILED);
@@ -276,7 +278,7 @@ class NegotiationServiceTest {
             given(waitingTicketRepository.findById(20L)).willReturn(Optional.of(buyerTicket));
 
             // when & then - 서비스가 sellerTicket 조회 후 도메인 메서드 호출 → FINAL_ROUND 아님 예외
-            assertThatThrownBy(() -> negotiationService.submitFinalOffer(1L, 2L, 7000L))
+            assertThatThrownBy(() -> negotiationService.submitFinalOffer(new NegotiationFinalOfferCommand(1L, 2L, 7000L)))
                     .isInstanceOf(BusinessException.class)
                     .extracting("baseCode")
                     .isEqualTo(NegotiationCode.NEGOTIATION_INVALID_STATE);
@@ -294,10 +296,10 @@ class NegotiationServiceTest {
             given(waitingTicketRepository.findById(10L)).willReturn(Optional.of(sellerTicket));
             given(waitingTicketRepository.findById(20L)).willReturn(Optional.of(buyerTicket));
 
-            negotiationService.submitFinalOffer(1L, 2L, 8000L); // 구매자 1차 제출
+            negotiationService.submitFinalOffer(new NegotiationFinalOfferCommand(1L, 2L, 8000L)); // 구매자 1차 제출
 
             // when & then - 구매자 재제출
-            assertThatThrownBy(() -> negotiationService.submitFinalOffer(1L, 2L, 7000L))
+            assertThatThrownBy(() -> negotiationService.submitFinalOffer(new NegotiationFinalOfferCommand(1L, 2L, 7000L)))
                     .isInstanceOf(BusinessException.class)
                     .extracting("baseCode")
                     .isEqualTo(NegotiationCode.ALREADY_SUBMITTED_FINAL_OFFER);

--- a/src/test/java/com/intime/application/store/StoreServiceTest.java
+++ b/src/test/java/com/intime/application/store/StoreServiceTest.java
@@ -1,5 +1,7 @@
 package com.intime.application.store;
 
+import com.intime.application.store.dto.StoreCreateCommand;
+import com.intime.application.store.dto.StoreInfo;
 import com.intime.common.exception.BusinessException;
 import com.intime.domain.store.Store;
 import com.intime.domain.store.StoreCode;
@@ -39,15 +41,16 @@ class StoreServiceTest {
         @DisplayName("성공 : 가게 생성")
         void createStore() {
             // given
+            StoreCreateCommand command = new StoreCreateCommand("하뚜분식", "서울시 양천구", 30);
             given(storeRepository.save(any(Store.class))).willAnswer(inv -> inv.getArgument(0));
 
             // when
-            Store result = storeService.createStore("하뚜분식", "서울시 양천구", 30);
+            StoreInfo result = storeService.createStore(command);
 
             // then
-            assertThat(result.getName()).isEqualTo("하뚜분식");
-            assertThat(result.getAddress()).isEqualTo("서울시 양천구");
-            assertThat(result.getEstimatedWaitMinutes()).isEqualTo(30);
+            assertThat(result.name()).isEqualTo("하뚜분식");
+            assertThat(result.address()).isEqualTo("서울시 양천구");
+            assertThat(result.estimatedWaitMinutes()).isEqualTo(30);
         }
     }
 
@@ -63,10 +66,10 @@ class StoreServiceTest {
             given(storeRepository.findById(1L)).willReturn(Optional.of(store));
 
             // when
-            Store result = storeService.getStore(1L);
+            StoreInfo result = storeService.getStore(1L);
 
             // then
-            assertThat(result.getId()).isEqualTo(1L);
+            assertThat(result.id()).isEqualTo(1L);
         }
 
         @Test
@@ -98,7 +101,7 @@ class StoreServiceTest {
             given(storeRepository.findAll()).willReturn(stores);
 
             // when
-            List<Store> result = storeService.getStores();
+            List<StoreInfo> result = storeService.getStores();
 
             // then
             assertThat(result).hasSize(2);

--- a/src/test/java/com/intime/application/trade/ExchangeRequestServiceTest.java
+++ b/src/test/java/com/intime/application/trade/ExchangeRequestServiceTest.java
@@ -1,11 +1,14 @@
 package com.intime.application.trade;
 
+import com.intime.application.trade.dto.ExchangeRequestCommand;
+import com.intime.application.trade.dto.ExchangeRequestInfo;
 import com.intime.application.trade.fixture.ExchangeRequestFixture;
 import com.intime.application.trade.fixture.TradePostFixture;
 import com.intime.common.exception.BusinessException;
+import com.intime.domain.negotiation.Negotiation;
 import com.intime.domain.negotiation.NegotiationRepository;
+import com.intime.domain.negotiation.NegotiationStatus;
 import com.intime.domain.trade.*;
-import com.intime.domain.waiting.WaitingCode;
 import com.intime.domain.waiting.WaitingTicket;
 import com.intime.domain.waiting.WaitingTicketRepository;
 import com.intime.support.fixture.WaitingTicketFixture;
@@ -13,6 +16,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -28,10 +32,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-
-import com.intime.domain.negotiation.Negotiation;
-import com.intime.domain.negotiation.NegotiationStatus;
-import org.mockito.ArgumentCaptor;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ExchangeRequestService 단위 테스트")
@@ -78,8 +78,9 @@ class ExchangeRequestServiceTest {
         void requestExchangeSuccess() {
             // given
             setupClock();
-            TradePost post = TradePostFixture.createPost(1L, 10L, 1L, 1L); // sellerId=1
-            WaitingTicket buyerTicket = WaitingTicketFixture.createTicket(2L, 1L, 2L, 2, 2); // memberId=2
+            ExchangeRequestCommand command = new ExchangeRequestCommand(1L, 2L, 2L, 10000L);
+            TradePost post = TradePostFixture.createPost(1L, 10L, 1L, 1L);
+            WaitingTicket buyerTicket = WaitingTicketFixture.createTicket(2L, 1L, 2L, 2, 2);
             given(tradePostRepository.findById(1L)).willReturn(Optional.of(post));
             given(exchangeRequestRepository.existsByTradePostIdAndBuyerIdAndStatusIn(
                     1L, 2L, List.of(ExchangeRequestStatus.PENDING, ExchangeRequestStatus.SELECTED)))
@@ -88,26 +89,27 @@ class ExchangeRequestServiceTest {
             given(exchangeRequestRepository.save(any(ExchangeRequest.class))).willAnswer(inv -> inv.getArgument(0));
 
             // when
-            ExchangeRequest result = exchangeRequestService.requestExchange(1L, 2L, 2L, 10000L);
+            ExchangeRequestInfo result = exchangeRequestService.requestExchange(command);
 
             // then
-            assertThat(result.getStatus()).isEqualTo(ExchangeRequestStatus.PENDING);
-            assertThat(result.getOfferPrice()).isEqualTo(10000L);
-            assertThat(result.getExpiresAt()).isEqualTo(FIXED_NOW.plusMinutes(5));
+            assertThat(result.status()).isEqualTo(ExchangeRequestStatus.PENDING);
+            assertThat(result.offerPrice()).isEqualTo(10000L);
+            assertThat(result.expiresAt()).isEqualTo(FIXED_NOW.plusMinutes(5));
         }
 
         @Test
         @DisplayName("실패 : 동일 포스트에 PENDING/SELECTED 신청이 있으면 예외")
         void requestExchangeDuplicate() {
             // given
-            TradePost post = TradePostFixture.createPost(1L, 10L, 1L, 1L); // sellerId=1
+            ExchangeRequestCommand command = new ExchangeRequestCommand(1L, 2L, 2L, 10000L);
+            TradePost post = TradePostFixture.createPost(1L, 10L, 1L, 1L);
             given(tradePostRepository.findById(1L)).willReturn(Optional.of(post));
             given(exchangeRequestRepository.existsByTradePostIdAndBuyerIdAndStatusIn(
                     1L, 2L, List.of(ExchangeRequestStatus.PENDING, ExchangeRequestStatus.SELECTED)))
                     .willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> exchangeRequestService.requestExchange(1L, 2L, 2L, 10000L))
+            assertThatThrownBy(() -> exchangeRequestService.requestExchange(command))
                     .isInstanceOf(BusinessException.class)
                     .extracting("baseCode")
                     .isEqualTo(ExchangeRequestCode.EXCHANGE_REQUEST_DUPLICATE);
@@ -117,6 +119,7 @@ class ExchangeRequestServiceTest {
         @DisplayName("실패 : buyerTicket WAITING 아닌 경우 예외")
         void buyerTicketNotWaiting() {
             // given
+            ExchangeRequestCommand command = new ExchangeRequestCommand(1L, 2L, 2L, 10000L);
             TradePost post = TradePostFixture.createPost(1L, 10L, 1L, 1L);
             WaitingTicket buyerTicket = WaitingTicketFixture.createTicket(2L, 1L, 2L, 2, 2);
             buyerTicket.call(LocalDateTime.now());
@@ -127,7 +130,7 @@ class ExchangeRequestServiceTest {
             given(waitingTicketRepository.findById(2L)).willReturn(Optional.of(buyerTicket));
 
             // when & then
-            assertThatThrownBy(() -> exchangeRequestService.requestExchange(1L, 2L, 2L, 10000L))
+            assertThatThrownBy(() -> exchangeRequestService.requestExchange(command))
                     .isInstanceOf(BusinessException.class)
                     .extracting("baseCode")
                     .isEqualTo(ExchangeRequestCode.BUYER_TICKET_NOT_WAITING);
@@ -137,11 +140,12 @@ class ExchangeRequestServiceTest {
         @DisplayName("실패 : 본인 포스트에 신청 시 예외")
         void requestSelfPost() {
             // given
-            TradePost post = TradePostFixture.createPost(1L, 10L, 2L, 1L); // sellerId=2 (same as buyerId)
+            ExchangeRequestCommand command = new ExchangeRequestCommand(1L, 2L, 2L, 10000L);
+            TradePost post = TradePostFixture.createPost(1L, 10L, 2L, 1L);
             given(tradePostRepository.findById(1L)).willReturn(Optional.of(post));
 
             // when & then
-            assertThatThrownBy(() -> exchangeRequestService.requestExchange(1L, 2L, 2L, 10000L))
+            assertThatThrownBy(() -> exchangeRequestService.requestExchange(command))
                     .isInstanceOf(BusinessException.class)
                     .extracting("baseCode")
                     .isEqualTo(ExchangeRequestCode.EXCHANGE_REQUEST_SELF_POST);
@@ -151,8 +155,9 @@ class ExchangeRequestServiceTest {
         @DisplayName("실패 : buyerTicket 소유자 아닌 경우 예외")
         void buyerTicketNotOwner() {
             // given
+            ExchangeRequestCommand command = new ExchangeRequestCommand(1L, 2L, 2L, 10000L);
             TradePost post = TradePostFixture.createPost(1L, 10L, 1L, 1L);
-            WaitingTicket buyerTicket = WaitingTicketFixture.createTicket(2L, 1L, 3L, 2, 2); // owned by memberId=3
+            WaitingTicket buyerTicket = WaitingTicketFixture.createTicket(2L, 1L, 3L, 2, 2);
             given(tradePostRepository.findById(1L)).willReturn(Optional.of(post));
             given(exchangeRequestRepository.existsByTradePostIdAndBuyerIdAndStatusIn(
                     1L, 2L, List.of(ExchangeRequestStatus.PENDING, ExchangeRequestStatus.SELECTED)))
@@ -160,7 +165,7 @@ class ExchangeRequestServiceTest {
             given(waitingTicketRepository.findById(2L)).willReturn(Optional.of(buyerTicket));
 
             // when & then
-            assertThatThrownBy(() -> exchangeRequestService.requestExchange(1L, 2L, 2L, 10000L))
+            assertThatThrownBy(() -> exchangeRequestService.requestExchange(command))
                     .isInstanceOf(BusinessException.class)
                     .extracting("baseCode")
                     .isEqualTo(ExchangeRequestCode.BUYER_TICKET_NOT_OWNER);
@@ -210,7 +215,7 @@ class ExchangeRequestServiceTest {
             // given
             setupClock();
             ExchangeRequest request = ExchangeRequestFixture.createRequest(1L, 1L, 2L, 2L);
-            TradePost post = TradePostFixture.createPost(1L, 10L, 1L, 1L); // sellerId=1
+            TradePost post = TradePostFixture.createPost(1L, 10L, 1L, 1L);
             given(exchangeRequestRepository.findById(1L)).willReturn(Optional.of(request));
             given(tradePostRepository.findById(1L)).willReturn(Optional.of(post));
             given(negotiationRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
@@ -236,7 +241,7 @@ class ExchangeRequestServiceTest {
         void selectByNonOwner() {
             // given
             ExchangeRequest request = ExchangeRequestFixture.createRequest(1L, 1L, 2L, 2L);
-            TradePost post = TradePostFixture.createPost(1L, 10L, 1L, 1L); // sellerId=1
+            TradePost post = TradePostFixture.createPost(1L, 10L, 1L, 1L);
             given(exchangeRequestRepository.findById(1L)).willReturn(Optional.of(request));
             given(tradePostRepository.findById(1L)).willReturn(Optional.of(post));
 

--- a/src/test/java/com/intime/application/trade/TradePostServiceTest.java
+++ b/src/test/java/com/intime/application/trade/TradePostServiceTest.java
@@ -1,5 +1,7 @@
 package com.intime.application.trade;
 
+import com.intime.application.trade.dto.TradePostInfo;
+import com.intime.application.trade.dto.TradePostRegisterCommand;
 import com.intime.application.trade.fixture.TradePostFixture;
 import com.intime.common.exception.BusinessException;
 import com.intime.domain.trade.*;
@@ -52,17 +54,18 @@ class TradePostServiceTest {
         void registerSuccess() {
             // given
             WaitingTicket ticket = WaitingTicketFixture.createTicket(1L, 1L, 1L, 1, 2);
+            TradePostRegisterCommand command = new TradePostRegisterCommand(1L, 1L, null);
             given(waitingTicketRepository.findById(1L)).willReturn(Optional.of(ticket));
             given(tradePostRepository.existsByWaitingTicketIdAndStatus(1L, TradePostStatus.OPEN)).willReturn(false);
             given(tradePostRepository.save(any(TradePost.class))).willAnswer(inv -> inv.getArgument(0));
 
             // when
-            TradePost result = tradePostService.register(1L, 1L, null);
+            TradePostInfo result = tradePostService.register(command);
 
             // then
-            assertThat(result.getStatus()).isEqualTo(TradePostStatus.OPEN);
-            assertThat(result.getSellerId()).isEqualTo(1L);
-            assertThat(result.getStoreId()).isEqualTo(ticket.getStoreId());
+            assertThat(result.status()).isEqualTo(TradePostStatus.OPEN);
+            assertThat(result.sellerId()).isEqualTo(1L);
+            assertThat(result.storeId()).isEqualTo(ticket.getStoreId());
         }
 
         @Test
@@ -71,10 +74,11 @@ class TradePostServiceTest {
             // given
             WaitingTicket ticket = WaitingTicketFixture.createTicket(1L, 1L, 1L, 1, 2);
             ticket.call(LocalDateTime.now());
+            TradePostRegisterCommand command = new TradePostRegisterCommand(1L, 1L, null);
             given(waitingTicketRepository.findById(1L)).willReturn(Optional.of(ticket));
 
             // when & then
-            assertThatThrownBy(() -> tradePostService.register(1L, 1L, null))
+            assertThatThrownBy(() -> tradePostService.register(command))
                     .isInstanceOf(BusinessException.class);
         }
 
@@ -83,10 +87,11 @@ class TradePostServiceTest {
         void registerNotOwner() {
             // given
             WaitingTicket ticket = WaitingTicketFixture.createTicket(1L, 1L, 1L, 1, 2);
+            TradePostRegisterCommand command = new TradePostRegisterCommand(1L, 999L, null);
             given(waitingTicketRepository.findById(1L)).willReturn(Optional.of(ticket));
 
             // when & then
-            assertThatThrownBy(() -> tradePostService.register(1L, 999L, null))
+            assertThatThrownBy(() -> tradePostService.register(command))
                     .isInstanceOf(BusinessException.class);
         }
 
@@ -95,11 +100,12 @@ class TradePostServiceTest {
         void registerDuplicate() {
             // given
             WaitingTicket ticket = WaitingTicketFixture.createTicket(1L, 1L, 1L, 1, 2);
+            TradePostRegisterCommand command = new TradePostRegisterCommand(1L, 1L, null);
             given(waitingTicketRepository.findById(1L)).willReturn(Optional.of(ticket));
             given(tradePostRepository.existsByWaitingTicketIdAndStatus(1L, TradePostStatus.OPEN)).willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> tradePostService.register(1L, 1L, null))
+            assertThatThrownBy(() -> tradePostService.register(command))
                     .isInstanceOf(BusinessException.class);
         }
     }

--- a/src/test/java/com/intime/application/waiting/WaitingQueryServiceTest.java
+++ b/src/test/java/com/intime/application/waiting/WaitingQueryServiceTest.java
@@ -1,6 +1,10 @@
 package com.intime.application.waiting;
 
+import com.intime.application.waiting.dto.WaitingPositionInfo;
+import com.intime.application.waiting.dto.WaitingTicketInfo;
 import com.intime.domain.store.Store;
+import com.intime.domain.store.StoreRepository;
+import com.intime.domain.trade.TradePostRepository;
 import com.intime.domain.waiting.WaitingStatus;
 import com.intime.domain.waiting.WaitingTicket;
 import com.intime.domain.waiting.WaitingTicketRepository;
@@ -31,7 +35,10 @@ class WaitingQueryServiceTest {
     private WaitingTicketRepository waitingTicketRepository;
 
     @Mock
-    private com.intime.domain.store.StoreRepository storeRepository;
+    private StoreRepository storeRepository;
+
+    @Mock
+    private TradePostRepository tradePostRepository;
 
     @Nested
     @DisplayName("getStoreQueue 메서드")
@@ -50,11 +57,11 @@ class WaitingQueryServiceTest {
                     .willReturn(tickets);
 
             // when
-            List<WaitingTicket> result = waitingQueryService.getStoreQueue(1L);
+            List<WaitingTicketInfo> result = waitingQueryService.getStoreQueue(1L);
 
             // then
             assertThat(result).hasSize(2);
-            assertThat(result.get(0).getPositionNumber()).isEqualTo(1);
+            assertThat(result.get(0).positionNumber()).isEqualTo(1);
         }
     }
 
@@ -73,7 +80,7 @@ class WaitingQueryServiceTest {
                     .willReturn(tickets);
 
             // when
-            List<WaitingTicket> result = waitingQueryService.getMyTickets(1L);
+            List<WaitingTicketInfo> result = waitingQueryService.getMyTickets(1L);
 
             // then
             assertThat(result).hasSize(1);
@@ -97,7 +104,7 @@ class WaitingQueryServiceTest {
             given(storeRepository.findById(1L)).willReturn(Optional.of(store));
 
             // when
-            WaitingPositionResponse result = waitingQueryService.getMyPosition(1L);
+            WaitingPositionInfo result = waitingQueryService.getMyPosition(1L);
 
             // then
             assertThat(result.aheadCount()).isEqualTo(2);

--- a/src/test/java/com/intime/application/waiting/WaitingServiceTest.java
+++ b/src/test/java/com/intime/application/waiting/WaitingServiceTest.java
@@ -1,7 +1,9 @@
 package com.intime.application.waiting;
 
-import com.intime.common.exception.BusinessException;
 import com.intime.application.trade.TradePostEventPublisher;
+import com.intime.application.waiting.dto.WaitingRegisterCommand;
+import com.intime.application.waiting.dto.WaitingTicketInfo;
+import com.intime.common.exception.BusinessException;
 import com.intime.domain.negotiation.Negotiation;
 import com.intime.domain.negotiation.NegotiationRepository;
 import com.intime.domain.trade.ExchangeRequestRepository;
@@ -83,6 +85,7 @@ class WaitingServiceTest {
         void registerFirst() {
             // given
             setupClock();
+            WaitingRegisterCommand command = new WaitingRegisterCommand(1L, 1L, 2);
             given(waitingTicketRepository.existsByMemberIdAndStoreIdAndWaitingDateAndStatusIn(
                     1L, 1L, FIXED_DATE, List.of(WaitingStatus.WAITING, WaitingStatus.CALLED)))
                     .willReturn(false);
@@ -92,11 +95,11 @@ class WaitingServiceTest {
                     .willAnswer(invocation -> invocation.getArgument(0));
 
             // when
-            WaitingTicket result = waitingService.register(1L, 1L, 2);
+            WaitingTicketInfo result = waitingService.register(command);
 
             // then
-            assertThat(result.getPositionNumber()).isEqualTo(1);
-            assertThat(result.getStatus()).isEqualTo(WaitingStatus.WAITING);
+            assertThat(result.positionNumber()).isEqualTo(1);
+            assertThat(result.status()).isEqualTo(WaitingStatus.WAITING);
         }
 
         @Test
@@ -104,6 +107,7 @@ class WaitingServiceTest {
         void registerNext() {
             // given
             setupClock();
+            WaitingRegisterCommand command = new WaitingRegisterCommand(1L, 1L, 2);
             WaitingTicket existing = WaitingTicketFixture.createTicket(1L, 1L, 2L, 3, 2);
             given(waitingTicketRepository.existsByMemberIdAndStoreIdAndWaitingDateAndStatusIn(
                     1L, 1L, FIXED_DATE, List.of(WaitingStatus.WAITING, WaitingStatus.CALLED)))
@@ -114,10 +118,10 @@ class WaitingServiceTest {
                     .willAnswer(invocation -> invocation.getArgument(0));
 
             // when
-            WaitingTicket result = waitingService.register(1L, 1L, 2);
+            WaitingTicketInfo result = waitingService.register(command);
 
             // then
-            assertThat(result.getPositionNumber()).isEqualTo(4);
+            assertThat(result.positionNumber()).isEqualTo(4);
         }
 
         @Test
@@ -125,12 +129,13 @@ class WaitingServiceTest {
         void registerDuplicate() {
             // given
             setupClock();
+            WaitingRegisterCommand command = new WaitingRegisterCommand(1L, 1L, 2);
             given(waitingTicketRepository.existsByMemberIdAndStoreIdAndWaitingDateAndStatusIn(
                     1L, 1L, FIXED_DATE, List.of(WaitingStatus.WAITING, WaitingStatus.CALLED)))
                     .willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> waitingService.register(1L, 1L, 2))
+            assertThatThrownBy(() -> waitingService.register(command))
                     .isInstanceOf(BusinessException.class)
                     .extracting("baseCode")
                     .isEqualTo(WaitingCode.WAITING_DUPLICATE);
@@ -141,6 +146,7 @@ class WaitingServiceTest {
         void registerConflict() {
             // given
             setupClock();
+            WaitingRegisterCommand command = new WaitingRegisterCommand(1L, 1L, 2);
             given(waitingTicketRepository.existsByMemberIdAndStoreIdAndWaitingDateAndStatusIn(
                     1L, 1L, FIXED_DATE, List.of(WaitingStatus.WAITING, WaitingStatus.CALLED)))
                     .willReturn(false);
@@ -150,7 +156,7 @@ class WaitingServiceTest {
                     .willThrow(new DataIntegrityViolationException("Duplicate entry"));
 
             // when & then
-            assertThatThrownBy(() -> waitingService.register(1L, 1L, 2))
+            assertThatThrownBy(() -> waitingService.register(command))
                     .isInstanceOf(BusinessException.class)
                     .extracting("baseCode")
                     .isEqualTo(WaitingCode.WAITING_REGISTER_FAILED);
@@ -208,10 +214,10 @@ class WaitingServiceTest {
                     .willReturn(Optional.empty());
 
             // when
-            WaitingTicket result = waitingService.callNext(1L);
+            WaitingTicketInfo result = waitingService.callNext(1L);
 
             // then
-            assertThat(result.getStatus()).isEqualTo(WaitingStatus.CALLED);
+            assertThat(result.status()).isEqualTo(WaitingStatus.CALLED);
         }
 
         @Test
@@ -242,11 +248,10 @@ class WaitingServiceTest {
                     .willReturn(Optional.of(mock(Negotiation.class)));
 
             // when
-            WaitingTicket result = waitingService.callNext(1L);
+            WaitingTicketInfo result = waitingService.callNext(1L);
 
             // then
-            assertThat(result.getStatus()).isEqualTo(WaitingStatus.WAITING);
-            assertThat(result.getPendingCallAt()).isNotNull();
+            assertThat(result.status()).isEqualTo(WaitingStatus.WAITING);
         }
     }
 


### PR DESCRIPTION
## 변경 사항 요약

Service 입출력을 Command/Info DTO로 교체하여 엔티티 노출 제거 및 레이어 간 결합도 완화

Closes #48

---

## 주요 변경 사항

### 1. application 계층 DTO 도입 (전 도메인)

**Command DTO** — Service 입력 캡슐화

- `MemberSignupCommand`, `StoreCreateCommand`, `WaitingRegisterCommand`
- `TradePostRegisterCommand`, `ExchangeRequestCommand`
- `NegotiationOfferCommand`, `NegotiationFinalOfferCommand`

**Info DTO** — 엔티티 대체 Service 반환 타입

- `MemberInfo`, `StoreInfo`, `WaitingTicketInfo`, `WaitingPositionInfo`
- `TradePostInfo`, `ExchangeRequestInfo`, `NegotiationInfo`
- 각 Info DTO에 `from(Entity)` 팩토리 메서드 포함

### 2. presentation 계층 정리

**Controller (전 도메인)**

- `@RequestBody` Request DTO → Command DTO 변환 후 Service 호출
- Service에서 받은 Info DTO 그대로 반환 — 별도 변환 없음
- 도메인 엔티티 import 완전 제거

**삭제된 Response DTO**

- `MemberResponse`, `StoreResponse`, `WaitingTicketResponse`
- `TradePostResponse`, `ExchangeRequestResponse`, `NegotiationResponse`

### 3. Waiting enrichment 이동

**WaitingQueryController → WaitingQueryServiceImpl**

- `TradePostService` 의존성 Controller에서 제거
- `TradePostRepository` 직접 사용으로 단일 쿼리 + Map 매핑

### 4. DB 인덱스 보완

**ExchangeRequest**

- `(trade_post_id)` → `(trade_post_id, status)` 복합 인덱스로 교체
- `(buyer_ticket_id, status)`, `(buyer_id)` 인덱스 추가

**Negotiation**

- `uniqueConstraint`와 중복된 `idx_negotiation_exchange_request` 제거

---

## 동작 흐름

### Request → Response 흐름

```
HTTP Request
  → Controller: RequestBody 역직렬화
  → Command DTO 생성
  → Service 호출
  → Info DTO 반환
  → ResponseEntity<Info> 응답
```

---

## 기술적 의사결정

### 왜 Response DTO 없이 Info를 직접 반환하는가?

**문제**
- Info와 Response 필드가 동일한데 변환 레이어가 추가되면 불필요한 boilerplate 발생

**해결**
- presentation → application 의존은 정방향(허용)이므로 Info를 그대로 반환
- 추후 API 응답 형태가 달라지면 그때 Response DTO 추가

**비교**
- Response DTO 유지: 필드 완전 일치 시 변환 비용만 늘어남

### 왜 enrichment를 WaitingQueryService로 이동했는가?

**문제**
- Controller가 2개 Service를 조합하는 건 Controller 책임 초과

**해결**
- `TradePostRepository`를 WaitingQueryServiceImpl에 직접 주입
- 단일 쿼리 + Map으로 N+1 없이 enrichment 처리

**비교**
- TradePostService 경유: 동일 쿼리를 Service 경계를 넘어 호출하는 것뿐

---

## 완료 항목

- [x] Service 입력을 Command DTO로 캡슐화하여 비즈니스 의도 명확화
- [x] Service 반환 타입을 Info DTO로 교체하여 엔티티 노출 제거
- [x] presentation 계층에서 도메인 엔티티 import 완전 제거
- [x] Controller를 Request→Command 변환과 Info 전달만 담당하도록 단순화
- [x] 가게 대기열 조회의 거래 게시글 enrichment 로직을 Controller에서 Service로 이동